### PR TITLE
Removing magic strings, enumerate notification placement

### DIFF
--- a/src/Carnac.Logic/Native/DetailedScreen.cs
+++ b/src/Carnac.Logic/Native/DetailedScreen.cs
@@ -13,9 +13,9 @@ namespace Carnac.Logic.Native
         public double Top { get; set; }
         public double Left { get; set; }
 
-        public bool Placement1 { get; set; }
-        public bool Placement2 { get; set; }
-        public bool Placement3 { get; set; }
-        public bool Placement4 { get; set; }
+        public bool NotificationPlacementTopLeft { get; set; }
+        public bool NotificationPlacementBottomLeft { get; set; }
+        public bool NotificationPlacementTopRight { get; set; }
+        public bool NotificationPlacementBottomRight { get; set; }
     }
 }

--- a/src/Carnac/Analects/Loader/Loader.cs
+++ b/src/Carnac/Analects/Loader/Loader.cs
@@ -14,6 +14,9 @@ namespace Analects.Loader
         private static readonly Dictionary<string, Assembly> libraries = new Dictionary<string, Assembly>();
         private static readonly Dictionary<string, Assembly> reflectionOnlyLibraries = new Dictionary<string, Assembly>();
 
+        private const string X86Environment = "x86";
+        private const string X64Environment = "x64";
+
         public static void Initialize()
         {
             AppDomain.CurrentDomain.AssemblyResolve += FindAssembly;
@@ -27,9 +30,9 @@ namespace Analects.Loader
         private static void PreloadUnmanagedLibraries()
         {
             // Preload correct library
-            var bittyness = "x86";
+            var bittyness = X86Environment;
             if (IntPtr.Size == 8)
-                bittyness = "x64";
+                bittyness = X64Environment;
 
             var assemblyName = Assembly.GetExecutingAssembly().GetName();
 
@@ -93,9 +96,9 @@ namespace Analects.Loader
             if (string.IsNullOrEmpty(actualName))
             {
                 // The library might be a mixed mode assembly. Try loading from the bitty folders.
-                var bittyness = "x86";
+                var bittyness = X86Environment;
                 if (IntPtr.Size == 8)
-                    bittyness = "x64";
+                    bittyness = X64Environment;
 
                 resourceName = String.Format("{0}.{3}.{1}.{2}.dll", assemblyName.Name, bittyness, shortName, LibsFolder);
                 actualName = executingAssembly.GetManifestResourceNames().FirstOrDefault(n => string.Equals(n, resourceName, StringComparison.OrdinalIgnoreCase));

--- a/src/Carnac/Carnac.csproj
+++ b/src/Carnac/Carnac.csproj
@@ -114,6 +114,7 @@
     <Compile Include="Analects\Loader\Loader.cs" />
     <Compile Include="Analects\SettingService\ISettingsService.cs" />
     <Compile Include="Analects\SettingService\SettingsService.cs" />
+    <Compile Include="Enum\NotificationPlacement.cs" />
     <Compile Include="KeyMonitor\HotKey.cs" />
     <Compile Include="KeyMonitor\HotKeyWinApi.cs" />
     <Compile Include="Models\Settings.cs" />
@@ -190,6 +191,7 @@
   <ItemGroup>
     <EmbeddedResource Include="icon.embedded.ico" />
   </ItemGroup>
+  <ItemGroup />
   <UsingTask TaskName="NotifyPropertyWeaverMsBuildTask.WeavingTask" AssemblyFile="$(SolutionDir)Tools\NotifyPropertyWeaverMsBuildTask.dll" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\nuget.targets" />

--- a/src/Carnac/Enum/NotificationPlacement.cs
+++ b/src/Carnac/Enum/NotificationPlacement.cs
@@ -1,0 +1,10 @@
+﻿namespace Carnac.Enum
+{
+    public enum NotificationPlacement
+    {
+        TopLeft = 1,
+        BottomLeft = 2,
+        TopRight = 3,
+        BottomRight = 4
+    }
+}

--- a/src/Carnac/Models/Settings.cs
+++ b/src/Carnac/Models/Settings.cs
@@ -1,9 +1,7 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using Caliburn.Micro;
 using System.Windows;
+using Carnac.Enum;
 using Carnac.Logic;
 
 namespace Carnac.Models
@@ -21,7 +19,7 @@ namespace Carnac.Models
         public int Screen { get; set; }
 
         [NotifyProperty(AlsoNotifyFor = new[] { "ScaleTransform", "Alignment" })]
-        public int Placement { get; set; }
+        public NotificationPlacement Placement { get; set; }
 
         //Used to determine which from it's leftmost co-ord
         public double Left { get; set; }
@@ -37,12 +35,12 @@ namespace Carnac.Models
 
         public double ScaleTransform
         {
-            get { return Placement == 1 || Placement == 3 ? 1 : -1; }
+            get { return Placement == NotificationPlacement.TopLeft || Placement == NotificationPlacement.TopRight ? 1 : -1; }
         }
 
         public string Alignment
         {
-            get { return Placement == 1 || Placement == 2 ? "Left" : "Right"; }
+            get { return Placement == NotificationPlacement.TopLeft || Placement == NotificationPlacement.BottomLeft ? "Left" : "Right"; }
         }
 
 
@@ -53,7 +51,7 @@ namespace Carnac.Models
 
         public string SortDescription
         {
-            get { return Placement == 1 || Placement == 3 ? "Ascending" : "Descending"; }
+            get { return Placement == NotificationPlacement.TopLeft || Placement == NotificationPlacement.TopRight ? "Ascending" : "Descending"; }
         }
     }
 }

--- a/src/Carnac/ViewModels/ShellViewModel.cs
+++ b/src/Carnac/ViewModels/ShellViewModel.cs
@@ -4,8 +4,8 @@ using System.ComponentModel.Composition;
 using System.Linq;
 using Analects.SettingsService;
 using Caliburn.Micro;
+using Carnac.Enum;
 using Carnac.Logic;
-using Carnac.Logic.KeyMonitor;
 using Carnac.Logic.Native;
 using Carnac.Models;
 using Carnac.Utilities;
@@ -169,15 +169,15 @@ namespace Carnac.ViewModels
 
             Settings.Screen = SelectedScreen.Index;
 
-            if (SelectedScreen.Placement1)
-                Settings.Placement = 1;
-            else if (SelectedScreen.Placement2)
-                Settings.Placement = 2;
-            else if (SelectedScreen.Placement3)
-                Settings.Placement = 3;
-            else if (SelectedScreen.Placement4)
-                Settings.Placement = 4;
-            else Settings.Placement = 2;
+               if (SelectedScreen.NotificationPlacementTopLeft)
+                Settings.Placement = NotificationPlacement.TopLeft;
+            else if (SelectedScreen.NotificationPlacementBottomLeft)
+                Settings.Placement = NotificationPlacement.BottomLeft;
+            else if (SelectedScreen.NotificationPlacementTopRight)
+                Settings.Placement = NotificationPlacement.TopRight;
+            else if (SelectedScreen.NotificationPlacementBottomRight)
+                Settings.Placement = NotificationPlacement.BottomRight;
+            else Settings.Placement = NotificationPlacement.BottomLeft;
 
             PlaceScreen();
 
@@ -203,15 +203,15 @@ namespace Carnac.ViewModels
 
             if (SelectedScreen == null) return;
 
-            if (Settings.Placement == 1)
-                SelectedScreen.Placement1 = true;
-            else if (Settings.Placement == 2)
-                SelectedScreen.Placement2 = true;
-            else if (Settings.Placement == 3)
-                SelectedScreen.Placement3 = true;
-            else if (Settings.Placement == 4)
-                SelectedScreen.Placement4 = true;
-            else SelectedScreen.Placement2 = true;
+            if (Settings.Placement == NotificationPlacement.TopLeft)
+                SelectedScreen.NotificationPlacementTopLeft = true;
+            else if (Settings.Placement == NotificationPlacement.BottomLeft)
+                SelectedScreen.NotificationPlacementBottomLeft = true;
+            else if (Settings.Placement == NotificationPlacement.TopRight)
+                SelectedScreen.NotificationPlacementTopRight = true;
+            else if (Settings.Placement == NotificationPlacement.BottomRight)
+                SelectedScreen.NotificationPlacementBottomRight = true;
+            else SelectedScreen.NotificationPlacementBottomLeft = true;
 
             Settings.Left = SelectedScreen.Left;
         }

--- a/src/Carnac/Views/ShellView.xaml
+++ b/src/Carnac/Views/ShellView.xaml
@@ -47,10 +47,10 @@
                                 <Grid HorizontalAlignment="Left" Height="{Binding RelativeHeight}" Margin="0" Width="{Binding RelativeWidth}">
                                     <Rectangle Fill="{DynamicResource AccentColorBrush}"/>
                                     <TextBlock FontWeight="SemiBold" TextWrapping="Wrap" Foreground="White" FontSize="96" VerticalAlignment="Center" HorizontalAlignment="Center" Text="{Binding Index}" />
-                                    <RadioButton x:Name="rbTL" Content="" IsChecked="{Binding Placement1}" Checked="RadioChecked" Tag="{Binding}" GroupName="Placement" HorizontalAlignment="Left" VerticalAlignment="Top" />
-                                    <RadioButton x:Name="rbBL" Content="" IsChecked="{Binding Placement2}" Checked="RadioChecked" Tag="{Binding}" GroupName="Placement" HorizontalAlignment="Left" VerticalAlignment="Bottom" />
-                                    <RadioButton x:Name="rbTR" Content="" IsChecked="{Binding Placement3}" Checked="RadioChecked" Tag="{Binding}" GroupName="Placement" HorizontalAlignment="Right" VerticalAlignment="Top" />
-                                    <RadioButton x:Name="rbBR" Content="" IsChecked="{Binding Placement4}" Checked="RadioChecked" Tag="{Binding}" GroupName="Placement" HorizontalAlignment="Right" VerticalAlignment="Bottom" />
+                                    <RadioButton x:Name="rbTL" Content="" IsChecked="{Binding NotificationPlacementTopLeft}" Checked="RadioChecked" Tag="{Binding}" GroupName="Placement" HorizontalAlignment="Left" VerticalAlignment="Top" />
+                                    <RadioButton x:Name="rbBL" Content="" IsChecked="{Binding NotificationPlacementBottomLeft}" Checked="RadioChecked" Tag="{Binding}" GroupName="Placement" HorizontalAlignment="Left" VerticalAlignment="Bottom" />
+                                    <RadioButton x:Name="rbTR" Content="" IsChecked="{Binding NotificationPlacementTopRight}" Checked="RadioChecked" Tag="{Binding}" GroupName="Placement" HorizontalAlignment="Right" VerticalAlignment="Top" />
+                                    <RadioButton x:Name="rbBR" Content="" IsChecked="{Binding NotificationPlacementBottomRight}" Checked="RadioChecked" Tag="{Binding}" GroupName="Placement" HorizontalAlignment="Right" VerticalAlignment="Bottom" />
                                 </Grid>
                                 <TextBlock FontWeight="SemiBold" HorizontalAlignment="Left" TextWrapping="Wrap" Text="{Binding FriendlyName}" FontSize="18.667"/>
                                 <TextBlock HorizontalAlignment="Left" TextWrapping="Wrap" FontSize="14">


### PR DESCRIPTION
Mostly just to facilitate learning the git process ;)

Added an enum for notification placement that we can use to reference in the view, model, etc. Rather than checking numbers, we can evaluate the actual 'placement'.
