### PR TITLE
KeyProviderTests fix

### DIFF
--- a/src/Carnac.Logic/KeyProvider.cs
+++ b/src/Carnac.Logic/KeyProvider.cs
@@ -80,12 +80,12 @@ namespace Carnac.Logic
             var isLetter = interceptKeyEventArgs.Key >= Keys.A &&
                            interceptKeyEventArgs.Key <= Keys.Z;
 
-            var inputs = ToInputs(isLetter, interceptKeyEventArgs);
+            var inputs = ToInputs(isLetter, winKeyPressed, interceptKeyEventArgs);
 
             return new KeyPress(process, interceptKeyEventArgs, winKeyPressed, inputs);
         }
 
-        private IEnumerable<string> ToInputs(bool isLetter, InterceptKeyEventArgs interceptKeyEventArgs)
+        private IEnumerable<string> ToInputs(bool isLetter, bool winKeyPressed, InterceptKeyEventArgs interceptKeyEventArgs)
         {
             var controlPressed = interceptKeyEventArgs.ControlPressed;
             var altPressed = interceptKeyEventArgs.AltPressed;

--- a/src/Carnac.Tests/KeyProviderTests.cs
+++ b/src/Carnac.Tests/KeyProviderTests.cs
@@ -27,7 +27,7 @@ namespace Carnac.Tests
             var processedKeys = ToEnumerable(provider, player);
 
             // assert
-            Assert.Equal(new[]{"Ctrl", "Shift", "L"}, processedKeys.Single().Input);
+            Assert.Equal(new[] { "Ctrl", "Shift", "L" }, processedKeys.Single().Input);
         }
 
         [Fact]
@@ -41,6 +41,7 @@ namespace Carnac.Tests
             var processedKeys = ToEnumerable(provider, player);
 
             // assert
+
             Assert.Equal(new[] { "L" }, processedKeys.Single().Input);
         }
 
@@ -97,8 +98,7 @@ namespace Carnac.Tests
             var processedKeys = ToEnumerable(provider, player);
 
             // assert
-            //TODO I think for this case we need to use the TestScheduler.. Someone that knows Rx can fix this test :)
-            //Assert.Equal(new[] { "Win", "E" }, processedKeys.Single().Input);
+            Assert.Equal(new[] { "Win", "e" }, processedKeys.Single().Input);
         }
 
         private IEnumerable<KeyPress> ToEnumerable(KeyProvider provider, KeyPlayer player)


### PR DESCRIPTION
Problem was in storing win key pressed information during all session. After input creation win key was in a wrong state.
