### PR TITLE
Fixed issue of missed windows up event when desktop locked

### DIFF
--- a/src/Carnac.Logic/Carnac.Logic.csproj
+++ b/src/Carnac.Logic/Carnac.Logic.csproj
@@ -35,6 +35,7 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
     <Reference Include="PropertyChanged">
       <HintPath>..\packages\PropertyChanged.Fody.1.49.0\Lib\portable-net4+sl4+wp8+win8+wpa81+MonoAndroid16+MonoTouch40\PropertyChanged.dll</HintPath>
@@ -66,6 +67,7 @@
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml" />
+    <Reference Include="WindowsBase" />
     <Reference Include="YamlDotNet.Core, Version=2.0.1.27808, Culture=neutral, PublicKeyToken=2b53052c5884d7a1, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\YamlDotNet.Core.2.2.0\lib\net35\YamlDotNet.Core.dll</HintPath>
@@ -83,6 +85,8 @@
     <Compile Include="IPasswordModeService.cs" />
     <Compile Include="IScreenManager.cs" />
     <Compile Include="IShortcutProvider.cs" />
+    <Compile Include="KeyMonitor\DesktopLockEventService.cs" />
+    <Compile Include="KeyMonitor\IDesktopLockEventService.cs" />
     <Compile Include="KeyMonitor\InterceptKeyEventArgs.cs" />
     <Compile Include="KeyMonitor\InterceptKeys.cs" />
     <Compile Include="KeyMonitor\KeyDirection.cs" />

--- a/src/Carnac.Logic/KeyMonitor/DesktopLockEventService.cs
+++ b/src/Carnac.Logic/KeyMonitor/DesktopLockEventService.cs
@@ -1,0 +1,35 @@
+using System;
+using Microsoft.Win32;
+
+namespace Carnac.Logic.KeyMonitor
+{
+    public class DesktopLockEventService : IDesktopLockEventService
+    {
+        public event EventHandler<EventArgs> DesktopUnlockedEvent;
+        public event EventHandler<EventArgs> DesktopLockedEvent;
+
+        public DesktopLockEventService()
+        {
+            SystemEvents.SessionSwitch += OnSystemEventsOnSessionSwitch;
+        }
+
+        void OnSystemEventsOnSessionSwitch(object sender, SessionSwitchEventArgs args)
+        {
+            if (args.Reason == SessionSwitchReason.SessionUnlock)
+            {
+                OnDesktopUnlockedEvent();
+            }
+        }
+
+        private void OnDesktopUnlockedEvent()
+        {
+            var handler = DesktopUnlockedEvent;
+            if (handler != null) handler(this, EventArgs.Empty);
+        }
+
+        public void Dispose()
+        {
+            SystemEvents.SessionSwitch += OnSystemEventsOnSessionSwitch;
+        }
+    }
+}

--- a/src/Carnac.Logic/KeyMonitor/IDesktopLockEventService.cs
+++ b/src/Carnac.Logic/KeyMonitor/IDesktopLockEventService.cs
@@ -1,0 +1,10 @@
+using System;
+
+namespace Carnac.Logic.KeyMonitor
+{
+    public interface IDesktopLockEventService : IDisposable
+    {
+        event EventHandler<EventArgs> DesktopUnlockedEvent;
+        event EventHandler<EventArgs> DesktopLockedEvent;
+    }
+}

--- a/src/Carnac/Carnac.csproj
+++ b/src/Carnac/Carnac.csproj
@@ -120,9 +120,9 @@
     <Reference Include="System.Xaml">
       <RequiredTargetFramework>4.0</RequiredTargetFramework>
     </Reference>
-    <Reference Include="WindowsBase" />
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
+    <Reference Include="WindowsBase" />
     <Reference Include="Xceed.Wpf.AvalonDock">
       <HintPath>..\packages\Extended.Wpf.Toolkit.2.0.0\lib\net40\Xceed.Wpf.AvalonDock.dll</HintPath>
     </Reference>


### PR DESCRIPTION
Added desktop lock event service used by InterceptKeys to simulate the
Windows key up event when a desktop is unlocked to match the current
state of the windows keys.

Basically what it does is when a desktop is locked, it tracks the state of the Windows key.  Then, when the desktop is unlocked it compares that saved state with current state and if they're different (i.e. the Windows key is no longer pressed) it sends the equivalent of a key up InterceptKeyEventArgs to get KeyProvider back in the plot.