### PR TITLE
Choco deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,8 @@
 
 A keyboard logging and presentation utility for presentations, screencasts, and to help you become a better keyboard user.
 
-## Build Status
+### Build Status
 [![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/julkdemv7hi4tg2b/branch/master?svg=true)](https://ci.appveyor.com/project/dustinvenegas/carnac/branch/master)
-
-## Chat Room
 
 ### Installation
 You can install via ClickOnce from [http://ginnivan.blob.core.windows.net/carnac/Carnac.application](http://ginnivan.blob.core.windows.net/carnac/Carnac.application)

--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 A keyboard logging and presentation utility for presentations, screencasts, and to help you become a better keyboard user.
 
+## Build Status
+[![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/julkdemv7hi4tg2b/branch/master?svg=true)](https://ci.appveyor.com/project/dustinvenegas/carnac/branch/master)
+
+## Chat Room
+
 ### Installation
 You can install via ClickOnce from [http://ginnivan.blob.core.windows.net/carnac/Carnac.application](http://ginnivan.blob.core.windows.net/carnac/Carnac.application)
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 1.0.{build}
+version: 0.0.0.{build}
 configuration: Debug
 assembly_info:
   patch: true
@@ -6,5 +6,19 @@ assembly_info:
   assembly_version: '{version}'
   assembly_file_version: '{version}'
   assembly_informational_version: '{version}'
+environment:
+  Version: $(APPVEYOR_BUILD_VERSION)
+  GithubRepo: $(APPVEYOR_REPO_NAME)
 build_script:
-- build.cmd
+- build.cmd Debug
+artifacts:
+- path: deploy\*.nupkg
+  name: ChocoPackage
+- path: deploy\*.zip
+  name: ZipPackage
+deploy:
+- provider: NuGet
+  server: https://www.myget.org/F/dustinvenegas/api/v2/package
+  api_key:
+    secure: YZ8Sveu3DcOr37XXEPN7Omx3lv2h7kfDH+7GKZ6emTJz3z9EqKtssiYAeu7b8wVn
+  artifact: ChocoPackage

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,10 @@
+version: 1.0.{build}
+configuration: Debug
+assembly_info:
+  patch: true
+  file: '**\AssemblyInfo.*'
+  assembly_version: '{version}'
+  assembly_file_version: '{version}'
+  assembly_informational_version: '{version}'
+build_script:
+- build.cmd

--- a/build.cmd
+++ b/build.cmd
@@ -4,4 +4,9 @@ if "%config%" == "" (
    set config=Debug
 )
 
+set version=%2
+if "%version%" == "" (
+   set version=%config%
+)
+
 %WINDIR%\Microsoft.NET\Framework\v4.0.30319\msbuild build.proj /p:Configuration="%config%" /t:package /m /v:M /fl /flp:LogFile=msbuild.log;Verbosity=Normal /nr:false

--- a/build.cmd
+++ b/build.cmd
@@ -1,4 +1,3 @@
-@echo Off
 set config=%1
 if "%config%" == "" (
    set config=Debug

--- a/build.cmd
+++ b/build.cmd
@@ -5,9 +5,4 @@ if "%config%" == "" (
    set config=Debug
 )
 
-set version=%2
-if "%version%" == "" (
-   set version="0.0.0.0"
-)
-
-%WINDIR%\Microsoft.NET\Framework\v4.0.30319\msbuild build.proj /p:Configuration="%config%";Version="%version%" /t:package /m /v:M /fl /flp:LogFile=msbuild.log;Verbosity=Normal /nr:false
+%WINDIR%\Microsoft.NET\Framework\v4.0.30319\msbuild build.proj /p:Configuration="%config%" /t:package /m /v:M /fl /flp:LogFile=msbuild.log;Verbosity=Normal /nr:false

--- a/build.cmd
+++ b/build.cmd
@@ -6,7 +6,7 @@ if "%config%" == "" (
 
 set version=%2
 if "%version%" == "" (
-   set version=%config%
+   set version="0.0.0.0"
 )
 
-%WINDIR%\Microsoft.NET\Framework\v4.0.30319\msbuild build.proj /p:Configuration="%config%" /t:package /m /v:M /fl /flp:LogFile=msbuild.log;Verbosity=Normal /nr:false
+%WINDIR%\Microsoft.NET\Framework\v4.0.30319\msbuild build.proj /p:Configuration="%config%";Version="%version%" /t:package /m /v:M /fl /flp:LogFile=msbuild.log;Verbosity=Normal /nr:false

--- a/build.cmd
+++ b/build.cmd
@@ -1,3 +1,5 @@
+@echo Off
+
 set config=%1
 if "%config%" == "" (
    set config=Debug

--- a/build.proj
+++ b/build.proj
@@ -7,6 +7,7 @@
     <Root>$(MSBuildProjectDirectory)\</Root>
     <CarnacProjectDir>$(Root)src\Carnac\</CarnacProjectDir>
     <OutputPath Condition="'$(OutputPath)' == ''">$(CarnacProjectDir)bin\$(Configuration)\</OutputPath>
+    <Version Condition="'$(Version)' == ''">0.0.0.9</Version>
   </PropertyGroup>
 
   <!--
@@ -94,7 +95,7 @@ Invoking the target:
     <xunit Assembly="@(TestFiles)" />
   </Target>
 
-  <Target Name="Package" DependsOnTargets="Test">
+  <Target Name="Package" DependsOnTargets="Test;PackageChoco">
     <!--http://msdn.microsoft.com/en-us/library/6wc2ccdc.aspx-->
     <PropertyGroup>
       <Thumbprint>
@@ -102,7 +103,6 @@ Invoking the target:
       </Thumbprint>
       <DeployUrl Condition="'$(DeployUrl)' == ''"></DeployUrl>
       <SupportUrl>https://github.com/Code52/carnac</SupportUrl>
-      <Version Condition="'$(Version)' == ''">0.0.0.9</Version>
       <VersionDir>$(OutputPath)$(Version)\</VersionDir>
       <AppManifest>$(VersionDir)Carnac.exe.manifest</AppManifest>
     </PropertyGroup>
@@ -177,6 +177,28 @@ Invoking the target:
     <Move SourceFiles="@(FilesToRename)" DestinationFiles="@(FilesToRename->'%(RootDir)%(Directory)%(FileName)%(Extension).deploy')" />
   </Target>
 
+  <Target Name="PackageChoco" DependsOnTargets="Test">
+    <Message Text="===========Package - Choco===========" Importance="High" />
+
+    <PropertyGroup>
+      <ChocoSourceDir>$(Root)\src\Chocolatey\</ChocoSourceDir>
+      <ChocoSpecPath>$(Root)\src\Chocolatey\carnac.nuspec</ChocoSpecPath>
+      <ChocoOutputDir>$(OutputPath)Chocolatey\</ChocoOutputDir>
+      <GithubOrg Condition="'$(GithubOrg)' == ''">Code52</GithubOrg>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <RegexTransform Include="$(ChocoSourceDir)\tools\chocolateyinstall.ps1">
+        <Find><![CDATA[\$url = '.+']]></Find>
+        <ReplaceWith>$url = 'https://github.com/$(GithubOrg)/carnac/releases/download/v$(Version)/carnac.$(Version).zip'</ReplaceWith>
+        <Options>Singleline</Options>
+      </RegexTransform>
+    </ItemGroup>
+    <RegexTransform Items="@(RegexTransform)" />
+
+    <MakeDir Directories="$(ChocoOutputPath)" />
+    <Exec Command="$(Root)src\.nuget\nuget.exe pack $(ChocoSpecPath) -OutputDirectory $(ChocoOutputDir) -Version $(Version) -NoPackageAnalysis" />
+  </Target>
 
   <Target Name="PublishInstallToAzure">
 
@@ -187,6 +209,15 @@ Invoking the target:
     <Move SourceFiles="$(OutputPath)Carnac.application" DestinationFolder="$(OutputPath)ClickOnceApplicationFile\" />
     <Exec Command="$(Root)tools\AzCopy.exe $(OutputPath) $(BlobTargetUrl) /destkey:$(BlobTargetKey) /S /V /Y" />
     <Exec Command="$(Root)tools\AzCopy.exe $(OutputPath)ClickOnceApplicationFile\ $(BlobTargetUrl) /destkey:$(BlobTargetKey) /S /V /Y" />
+  </Target>
+
+  <Target Name="PublishToChoco" DependsOnTargets="PackageChoco">
+    <PropertyGroup>
+      <ChocoFeedUrl Condition="'$(ChocoFeedUrl)' == ''">https://chocolatey.org/</ChocoFeedUrl>
+    </PropertyGroup>
+
+    <!--To publish to a chocolatey feed: msbuild build.proj /p:ChocoFeedUrl=https://chocolatey.org/ /p:ChocoApiKey=dUr1aN /target:PublishToChoco-->
+    <Exec Command="$(Root)src\.nuget\nuget.exe push $(ChocoOutputDir)carnac.$(Version).nupkg -apikey $(ChocoApiKey) -source $(ChocoFeedUrl)" />
   </Target>
 
 </Project>

--- a/build.proj
+++ b/build.proj
@@ -98,7 +98,7 @@
       <OutputFileName ParameterType="System.String" Required="true" />
       <OverwriteExistingFile ParameterType="System.Boolean" Required="false" />
       <IncludeBaseDirectory ParameterType="System.Boolean" Required="false" />
-	</ParameterGroup>
+    </ParameterGroup>
     <Task>
       <Reference Include="System.IO.Compression" />
       <Reference Include="System.IO.Compression.FileSystem" />

--- a/build.proj
+++ b/build.proj
@@ -7,29 +7,30 @@
     <Root>$(MSBuildProjectDirectory)\</Root>
     <CarnacProjectDir>$(Root)src\Carnac\</CarnacProjectDir>
     <OutputPath Condition="'$(OutputPath)' == ''">$(CarnacProjectDir)bin\$(Configuration)\</OutputPath>
+    <DeployPath>$(Root)deploy\</DeployPath>
     <Version Condition="'$(Version)' == ''">0.0.0.9</Version>
   </PropertyGroup>
 
   <!--
-============================================================
-            RegexTransform
- 
-Transforms the input Items parameter by evaluating the
-regular expression in their Find metadata and
-replacing with their ReplaceWith metadata. Optional, the
-options for the regular expression evaluation can be specified.
- 
-Example input item:
-        <RegexTransform Include="$(BuildRoot)Src\GlobalAssemblyInfo.cs">
-            <Find>AssemblyFileVersion\(".*?"\)</Find>
-            <ReplaceWith>AssemblyFileVersion("$(FileVersion)")</ReplaceWith>
-            <Options>Multiline | IgnorePatternWhitespace</Options>
-        </RegexTransform>
- 
-Invoking the target:
-    <RegexTransform Items="@(RegexTransform)" />
-============================================================
--->
+    ============================================================
+                RegexTransform
+     
+    Transforms the input Items parameter by evaluating the
+    regular expression in their Find metadata and
+    replacing with their ReplaceWith metadata. Optional, the
+    options for the regular expression evaluation can be specified.
+     
+    Example input item:
+            <RegexTransform Include="$(BuildRoot)Src\GlobalAssemblyInfo.cs">
+                <Find>AssemblyFileVersion\(".*?"\)</Find>
+                <ReplaceWith>AssemblyFileVersion("$(FileVersion)")</ReplaceWith>
+                <Options>Multiline | IgnorePatternWhitespace</Options>
+            </RegexTransform>
+     
+    Invoking the target:
+        <RegexTransform Items="@(RegexTransform)" />
+    ============================================================
+  -->
   <UsingTask TaskName="RegexTransform"
              TaskFactory="CodeTaskFactory"
              AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.v4.0.dll">
@@ -74,6 +75,54 @@ Invoking the target:
     </Task>
   </UsingTask>
 
+  <!--
+    ============================================================
+                ZipDir
+     
+     Zip a directory using MSBuild for .NET 4.5
+
+    See: 
+        https://github.com/moozzyk/MSBuild-Tasks
+     
+    Invoking the target:
+        <ZipDir
+          InputBaseDirectory="@(DirToZip)"
+          OutputFileName="$(ProjectDir)$(TargetZipFile)"
+          OverwriteExistingFile="false"
+          IncludeBaseDirectory="false" />
+    ============================================================
+  -->
+  <UsingTask TaskName="ZipDir" TaskFactory="CodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.v4.0.dll">
+    <ParameterGroup>
+      <InputBaseDirectory ParameterType="System.String" Required="true" />
+      <OutputFileName ParameterType="System.String" Required="true" />
+      <OverwriteExistingFile ParameterType="System.Boolean" Required="false" />
+      <IncludeBaseDirectory ParameterType="System.Boolean" Required="false" />
+	</ParameterGroup>
+    <Task>
+      <Reference Include="System.IO.Compression" />
+      <Reference Include="System.IO.Compression.FileSystem" />
+      <Using Namespace="System.IO.Compression" />
+      <Code Type="Fragment" Language="cs">
+      <![CDATA[        
+        if (File.Exists(OutputFileName))
+        {
+            if (!OverwriteExistingFile)
+            {
+                return false;
+            }
+            File.Delete(OutputFileName);
+        }
+        ZipFile.CreateFromDirectory
+        (
+            InputBaseDirectory, OutputFileName, 
+            CompressionLevel.Optimal, IncludeBaseDirectory
+        );
+      ]]>
+      </Code>
+    </Task>
+  </UsingTask>
+
   <Target Name="Restore">
     <Message Text=" ===========Restoring NuGet packages===========" Importance="High" />
     <Exec Command="$(Root)src\.nuget\nuget.exe restore $(Root)src\Carnac.sln" />
@@ -95,7 +144,7 @@ Invoking the target:
     <xunit Assembly="@(TestFiles)" />
   </Target>
 
-  <Target Name="Package" DependsOnTargets="Test;PackageChoco">
+  <Target Name="Package" DependsOnTargets="Test">
     <!--http://msdn.microsoft.com/en-us/library/6wc2ccdc.aspx-->
     <PropertyGroup>
       <Thumbprint>
@@ -177,7 +226,17 @@ Invoking the target:
     <Move SourceFiles="@(FilesToRename)" DestinationFiles="@(FilesToRename->'%(RootDir)%(Directory)%(FileName)%(Extension).deploy')" />
   </Target>
 
-  <Target Name="PackageChoco" DependsOnTargets="Test">
+  <Target Name="PackageZip" DependsOnTargets="Test">
+    <Message Text="===========Package - Zip===========" Importance="High" />
+
+    <ZipDir
+      InputBaseDirectory="$(OutputPath)"
+      OutputFileName="$(Root)\carnac.$(Version).zip"
+      OverwriteExistingFile="true"
+      IncludeBaseDirectory="false" />
+  </Target>
+
+  <Target Name="PackageChoco" DependsOnTargets="PackageZip">
     <Message Text="===========Package - Choco===========" Importance="High" />
 
     <PropertyGroup>
@@ -196,7 +255,7 @@ Invoking the target:
     </ItemGroup>
     <RegexTransform Items="@(RegexTransform)" />
 
-    <MakeDir Directories="$(ChocoOutputPath)" />
+    <MakeDir Directories="$(ChocoOutputDir)" />
     <Exec Command="$(Root)src\.nuget\nuget.exe pack $(ChocoSpecPath) -OutputDirectory $(ChocoOutputDir) -Version $(Version) -NoPackageAnalysis" />
   </Target>
 

--- a/build.proj
+++ b/build.proj
@@ -247,13 +247,13 @@
     <PropertyGroup>
       <ChocoSourceDir>$(Root)\src\Chocolatey\</ChocoSourceDir>
       <ChocoSpecPath>$(Root)\src\Chocolatey\carnac.nuspec</ChocoSpecPath>
-      <GithubOrg Condition="'$(GithubOrg)' == ''">Code52</GithubOrg>
+      <GithubRepo Condition="'$(GithubRepo)' == ''">Code52/carnac</GithubRepo>
     </PropertyGroup>
 
     <ItemGroup>
       <RegexTransform Include="$(ChocoSourceDir)\tools\chocolateyinstall.ps1">
         <Find><![CDATA[\$url = '.+']]></Find>
-        <ReplaceWith>$url = 'https://github.com/$(GithubOrg)/carnac/releases/download/v$(Version)/carnac.$(Version).zip'</ReplaceWith>
+        <ReplaceWith>$url = 'https://github.com/$(GithubRepo)/releases/download/v$(Version)/carnac.$(Version).zip'</ReplaceWith>
         <Options>Singleline</Options>
       </RegexTransform>
     </ItemGroup>

--- a/build.proj
+++ b/build.proj
@@ -144,7 +144,10 @@
     <xunit Assembly="@(TestFiles)" />
   </Target>
 
-  <Target Name="Package" DependsOnTargets="Test">
+  <Target Name="Package" DependsOnTargets="PackageZip;PackageOneClick;PackageChoco">
+  </Target>
+
+  <Target Name="PackageOneClick" DependsOnTargets="Test">
     <!--http://msdn.microsoft.com/en-us/library/6wc2ccdc.aspx-->
     <PropertyGroup>
       <Thumbprint>
@@ -152,7 +155,7 @@
       </Thumbprint>
       <DeployUrl Condition="'$(DeployUrl)' == ''"></DeployUrl>
       <SupportUrl>https://github.com/Code52/carnac</SupportUrl>
-      <VersionDir>$(OutputPath)$(Version)\</VersionDir>
+      <VersionDir>$(DeployPath)$(Version)\</VersionDir>
       <AppManifest>$(VersionDir)Carnac.exe.manifest</AppManifest>
     </PropertyGroup>
     <ItemGroup>
@@ -160,6 +163,7 @@
       <Keymaps Include="$(OutputPath)Keymaps\*.*" />
     </ItemGroup>
 
+    <MakeDir Directories="$(DeployPath)" />
     <Move SourceFiles="@(Keymaps)" DestinationFolder="$(VersionDir)Keymaps" />
     <Move SourceFiles="@(Dependencies)" DestinationFolder="$(VersionDir)" />
     <Move SourceFiles="$(OutputPath)Carnac.exe" DestinationFolder="$(VersionDir)" />
@@ -229,9 +233,10 @@
   <Target Name="PackageZip" DependsOnTargets="Test">
     <Message Text="===========Package - Zip===========" Importance="High" />
 
+    <MakeDir Directories="$(DeployPath)" />
     <ZipDir
       InputBaseDirectory="$(OutputPath)"
-      OutputFileName="$(Root)\carnac.$(Version).zip"
+      OutputFileName="$(DeployPath)\carnac.$(Version).zip"
       OverwriteExistingFile="true"
       IncludeBaseDirectory="false" />
   </Target>
@@ -242,7 +247,6 @@
     <PropertyGroup>
       <ChocoSourceDir>$(Root)\src\Chocolatey\</ChocoSourceDir>
       <ChocoSpecPath>$(Root)\src\Chocolatey\carnac.nuspec</ChocoSpecPath>
-      <ChocoOutputDir>$(OutputPath)Chocolatey\</ChocoOutputDir>
       <GithubOrg Condition="'$(GithubOrg)' == ''">Code52</GithubOrg>
     </PropertyGroup>
 
@@ -255,8 +259,8 @@
     </ItemGroup>
     <RegexTransform Items="@(RegexTransform)" />
 
-    <MakeDir Directories="$(ChocoOutputDir)" />
-    <Exec Command="$(Root)src\.nuget\nuget.exe pack $(ChocoSpecPath) -OutputDirectory $(ChocoOutputDir) -Version $(Version) -NoPackageAnalysis" />
+    <MakeDir Directories="$(DeployPath)" />
+    <Exec Command="$(Root)src\.nuget\nuget.exe pack $(ChocoSpecPath) -OutputDirectory $(DeployPath) -Version $(Version) -NoPackageAnalysis" />
   </Target>
 
   <Target Name="PublishInstallToAzure">
@@ -276,7 +280,7 @@
     </PropertyGroup>
 
     <!--To publish to a chocolatey feed: msbuild build.proj /p:ChocoFeedUrl=https://chocolatey.org/ /p:ChocoApiKey=dUr1aN /target:PublishToChoco-->
-    <Exec Command="$(Root)src\.nuget\nuget.exe push $(ChocoOutputDir)carnac.$(Version).nupkg -apikey $(ChocoApiKey) -source $(ChocoFeedUrl)" />
+    <Exec Command="$(Root)src\.nuget\nuget.exe push $(DeployPath)carnac.$(Version).nupkg -apikey $(ChocoApiKey) -source $(ChocoFeedUrl)" />
   </Target>
 
 </Project>

--- a/src/Chocolatey/carnac.nuspec
+++ b/src/Chocolatey/carnac.nuspec
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+  <metadata>
+    <id>carnac</id>
+    <title>carnac</title>
+    <version>0.0.0.9</version>
+    <authors>Code52</authors>
+    <owners>Dustin Venegas</owners>
+    <summary>A keyboard utility for all your Windows presentation needs</summary>
+    <description>
+        A keyboard utility for your Windows presentations, screencasts, and more. Carnac displays what you're typing in a modal as you type it.
+
+        This package installs into the Chocolatey lib folder, adds a user Start Menu entry, and adds carnac.exe as a Chocolatey bin executable. 
+    </description>
+    <projectUrl>https://github.com/Code52/carnac</projectUrl>
+    <tags>keyboard presentation screencast</tags>
+    <copyright>2015</copyright>
+    <licenseUrl>https://github.com/Code52/carnac/blob/master/LICENSE.md</licenseUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <iconUrl>https://cdn.rawgit.com/Code52/carnac/35d71121123471512e5623d1e8cbfae057d047d6/src/Carnac/carnac.png</iconUrl>
+    <releaseNotes>
+        Installs the from a release at [Code52 Github](https://github.com/downloads/Code52/carnac/)
+    </releaseNotes>
+  </metadata>
+  <files>
+    <file src="tools\**" target="tools" />
+  </files>
+</package>

--- a/src/Chocolatey/tools/chocolateyinstall.ps1
+++ b/src/Chocolatey/tools/chocolateyinstall.ps1
@@ -1,6 +1,6 @@
 ﻿$ErrorActionPreference = 'Stop';
 $packageName = 'carnac'
-$url = 'https://github.com/downloads/Code52/carnac/Carnac.zip'
+$url = 'Download Url Here'
 $toolsDir = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
 
 # Include Carnac.exe as a GUI in the bin install and ignore vshost.exe

--- a/src/Chocolatey/tools/chocolateyinstall.ps1
+++ b/src/Chocolatey/tools/chocolateyinstall.ps1
@@ -1,14 +1,15 @@
-﻿$ErrorActionPreference = 'Stop';
+$ErrorActionPreference = 'Stop';
 $packageName = 'carnac'
 $url = 'Download Url Here'
 $toolsDir = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
+$installDir = "$toolsDir\Carnac"
 
 # Include Carnac.exe as a GUI in the bin install and ignore vshost.exe
-New-Item -ItemType file -force -path "$toolsDir\Carnac\Carnac.exe.gui" | out-null
-New-Item -ItemType file -force -path "$toolsDir\Carnac\Carnac.vshost.exe.ignore" | out-null
+New-Item -ItemType file -force -path "$installDir\Carnac.exe.gui" | out-null
+New-Item -ItemType file -force -path "$installDir\Carnac.vshost.exe.ignore" | out-null
 
-Install-ChocolateyZipPackage "$packageName" "$url" "$toolsDir"
+Install-ChocolateyZipPackage "$packageName" "$url" "$installDir"
 
 # Create User start menu link
 $startMenuLink=$("$env:appdata\Microsoft\Windows\Start Menu\Programs\Carnac.lnk")
-Install-ChocolateyShortcut -shortcutFilePath $startMenuLink -targetPath "$toolsDir\Carnac\Carnac.exe" | out-null
+Install-ChocolateyShortcut -shortcutFilePath $startMenuLink -targetPath "$installDir\Carnac.exe" | out-null

--- a/src/Chocolatey/tools/chocolateyinstall.ps1
+++ b/src/Chocolatey/tools/chocolateyinstall.ps1
@@ -1,0 +1,14 @@
+﻿$ErrorActionPreference = 'Stop';
+$packageName = 'carnac'
+$url = 'https://github.com/downloads/Code52/carnac/Carnac.zip'
+$toolsDir = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
+
+# Include Carnac.exe as a GUI in the bin install and ignore vshost.exe
+New-Item -ItemType file -force -path "$toolsDir\Carnac\Carnac.exe.gui" | out-null
+New-Item -ItemType file -force -path "$toolsDir\Carnac\Carnac.vshost.exe.ignore" | out-null
+
+Install-ChocolateyZipPackage "$packageName" "$url" "$toolsDir"
+
+# Create User start menu link
+$startMenuLink=$("$env:appdata\Microsoft\Windows\Start Menu\Programs\Carnac.lnk")
+Install-ChocolateyShortcut -shortcutFilePath $startMenuLink -targetPath "$toolsDir\Carnac\Carnac.exe" | out-null


### PR DESCRIPTION
Fixes #97, #96, #70, #95 and includes all change sets. 

This includes the Chocolatey package and an appveyor configuration that performs a build, tests, and artifact creation. Some things are pointed to my personal appveyor account and need to be modified. Shoot me any questions if any come up during setup. 

**Todo Upon Merge**

* Create an appveyor account and link it to the Code52/carnac repository
* Readme.md - Change the badge
* Appveyor.yml - Remove the NuGet provider *or* modify it with updated credentials (can be encrypted in appveyor). I have a NuGet package created per-release
* Carnac.nuspec - ensure things look correct. The version is overwritten in the build.

**Process changes**

Chocolatey packages expect a pre-release or release Github tag on the Code52/carnac repository named `v$(appveyor_build_version)` with a download named `carnac.$(appveyor_build_version).zip`. This and a Chocolatey publish can be added to `Environments` within AppVeyor.

When releasing, I highly recommend publishing to github first and testing the Chocolatey package using any NuGet provider. Once verified, the package can be submitted to Chocolatey, which can also be automated using --api-key. Chocolatey does not allow deleting packages, only adding newer ones so it's important to verify them.

Let me know if you have any questions!