### PR TITLE
don't build tagged commits

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,7 @@
 version: 2.0.0.{build}
 configuration: Release
 skip_branch_with_pr: true
+skip_tags: true
 assembly_info:
   patch: true
   file: '**\AssemblyInfo.*'


### PR DESCRIPTION
A side-effect of the fix in #123 is that the tagged release done when deploying to GitHub releases is that the tagging process triggers a new build, which then creates a new release, which creates a new tag, and so on forever and ever probably...