### PR TITLE
Preferences view opens only once (Bugfix #134)

### DIFF
--- a/src/Carnac/CarnacTrayIcon.cs
+++ b/src/Carnac/CarnacTrayIcon.cs
@@ -41,6 +41,7 @@ namespace Carnac
         void NotifyIconClick(object sender, MouseEventArgs mouseEventArgs)
         {
             if (mouseEventArgs.Button == MouseButtons.Left)
+            {
                 var preferencesWindow = Application.Current.Windows.Cast<Window>().FirstOrDefault(x => x.Name == "PreferencesViewWindow");
                 if (preferencesWindow != null)
                 {
@@ -50,6 +51,7 @@ namespace Carnac
                 {
                     OpenPreferences();
                 }
+            }
         }
 
         public void Dispose()

--- a/src/Carnac/CarnacTrayIcon.cs
+++ b/src/Carnac/CarnacTrayIcon.cs
@@ -41,11 +41,10 @@ namespace Carnac
         void NotifyIconClick(object sender, MouseEventArgs mouseEventArgs)
         {
             if (mouseEventArgs.Button == MouseButtons.Left)
-                if (Application.Current.Windows.Cast<Window>().Any(x=>x.Name=="PreferencesViewWindow"))
+                var preferencesWindow = Application.Current.Windows.Cast<Window>().FirstOrDefault(x => x.Name == "PreferencesViewWindow");
+                if (preferencesWindow != null)
                 {
-                    Application.Current.Windows.Cast<Window>()
-                    .Where(x => x.Name == "PreferencesViewWindow")
-                    .ToArray()[0].Activate();                               //We have only one window, so the array has only one element
+                    preferencesWindow.Activate();
                 }
                 else
                 {

--- a/src/Carnac/CarnacTrayIcon.cs
+++ b/src/Carnac/CarnacTrayIcon.cs
@@ -2,6 +2,8 @@ using System;
 using System.Drawing;
 using System.Reflection;
 using System.Windows.Forms;
+using System.Linq;
+using System.Windows;
 using Application = System.Windows.Application;
 
 namespace Carnac
@@ -39,7 +41,16 @@ namespace Carnac
         void NotifyIconClick(object sender, MouseEventArgs mouseEventArgs)
         {
             if (mouseEventArgs.Button == MouseButtons.Left)
-                OpenPreferences();
+                if (Application.Current.Windows.Cast<Window>().Any(x=>x.Name=="PreferencesViewWindow"))
+                {
+                    Application.Current.Windows.Cast<Window>()
+                    .Where(x => x.Name == "PreferencesViewWindow")
+                    .ToArray()[0].Activate();                               //We have only one window, so the array has only one element
+                }
+                else
+                {
+                    OpenPreferences();
+                }
         }
 
         public void Dispose()

--- a/src/Carnac/UI/PreferencesView.xaml
+++ b/src/Carnac/UI/PreferencesView.xaml
@@ -11,7 +11,8 @@
                       Foreground="{DynamicResource BlackBrush}"
                       d:DataContext="{d:DesignInstance ui:PreferencesViewModel}" mc:Ignorable="d"
                       ShowTitleBar="False" ShowMinButton="False" ShowMaxRestoreButton="False"
-                      SaveWindowPosition="True" utilities:DesignTimeHelper.Background="Black">
+                      SaveWindowPosition="True" utilities:DesignTimeHelper.Background="Black"
+                      Name="PreferencesViewWindow">
     <Window.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>


### PR DESCRIPTION
Fixed the bug , reported in the issue:
https://github.com/Code52/carnac/issues/134.

The program checks, if the preferences view window is open, and if
it is, it sets the focus to the window.