### PR TITLE
Only pack the necessary files for this release

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -117,7 +117,17 @@ Task("Package-Zip")
 		EnsureDirectoryExists(deployDir);
 		EnsureDirectoryExists(gitHubDeployDir);
 
-		Zip(squirrelReleaseDir, zipFile);
+		var files = GetFiles($"{squirrelReleaseDir.Path}\\carnac-{version}-*.nupkg")
+			.Select(f => f.FullPath)
+			.Concat(
+				new []
+				{
+					$"{squirrelReleaseDir.Path}\\RELEASES",
+					$"{squirrelReleaseDir.Path}\\Setup.exe"
+				}
+			);
+		
+		Zip(squirrelReleaseDir, zipFile, files);
 		zipFileHash = CalculateFileHash(zipFile, HashAlgorithm.SHA256).ToHex();
 	});
 


### PR DESCRIPTION
We will currently pack the NuGet packages of the previous releases (used to generate the delta package for the new release), this is not necessary so we should only pack what is necessary, e.g.
- The `RELEASES` file
- The `Setup.exe` file
- The `carnac-{buildversion}-[full|delta].nupkg` files

Fixes #149 