### PR TITLE
Added option to only show keys which have a modifier

### DIFF
--- a/src/Carnac.Logic/MessageProvider.cs
+++ b/src/Carnac.Logic/MessageProvider.cs
@@ -37,7 +37,22 @@ namespace Carnac.Logic
                 .Where(c => c.HasCompletedValue)
                 .SelectMany(c => c.GetMessages())
                 .Scan(new Message(), (acc, key) => Message.MergeIfNeeded(acc, key))
-                .Where(m => !settings.DetectShortcutsOnly || m.IsShortcut);
+                .Where(m =>
+                {
+                    if (settings.DetectShortcutsOnly && settings.ShowOnlyModifiers)
+                    {
+                        return m.IsShortcut && m.IsModifier;
+                    }
+                    if (settings.DetectShortcutsOnly)
+                    {
+                        return m.IsShortcut;
+                    }
+                    if (settings.ShowOnlyModifiers)
+                    {
+                        return m.IsModifier;
+                    }
+                    return true;
+                });
         }
     }
 }

--- a/src/Carnac.Logic/Models/Message.cs
+++ b/src/Carnac.Logic/Models/Message.cs
@@ -15,6 +15,7 @@ namespace Carnac.Logic.Models
         readonly string shortcutName;
         readonly bool canBeMerged;
         readonly bool isShortcut;
+        readonly bool isModifier;
         readonly bool isDeleting;
         readonly DateTime lastMessage;
         readonly Message previous;
@@ -30,12 +31,13 @@ namespace Carnac.Logic.Models
             processName = key.Process.ProcessName;
             processIcon = key.Process.ProcessIcon;
             canBeMerged = !key.HasModifierPressed;
+            isModifier = key.HasModifierPressed;
 
             keys = new ReadOnlyCollection<KeyPress>(new[] { key });
             textCollection = new ReadOnlyCollection<string>(CreateTextSequence(key).ToArray());
         }
 
-        public Message(IEnumerable<KeyPress> keys, KeyShortcut shortcut)
+        public Message(IEnumerable<KeyPress> keys, KeyShortcut shortcut, Boolean isShortcut = false)
             : this()
         {
             var allKeys = keys.ToArray();
@@ -48,7 +50,8 @@ namespace Carnac.Logic.Models
             processName = distinctProcessName.Single();
             processIcon = allKeys.First().Process.ProcessIcon;
             shortcutName = shortcut.Name;
-            isShortcut = true;
+            this.isShortcut = isShortcut;
+            this.isModifier = allKeys.Any(k => k.HasModifierPressed);
             canBeMerged = false;
 
             this.keys = new ReadOnlyCollection<KeyPress>(allKeys);
@@ -91,7 +94,9 @@ namespace Carnac.Logic.Models
         public DateTime LastMessage { get { return lastMessage; } }
 
         public bool IsDeleting { get { return isDeleting; } }
-        
+
+        public bool IsModifier { get { return isModifier; } }
+
         public Message Merge(Message other)
         {
             return new Message(this, other);

--- a/src/Carnac.Logic/Models/PopupSettings.cs
+++ b/src/Carnac.Logic/Models/PopupSettings.cs
@@ -85,5 +85,6 @@ namespace Carnac.Logic.Models
         public bool DetectShortcutsOnly { get; set; }
         public bool ShowApplicationIcon { get; set; }
         public bool SettingsConfigured { get; set; }
+        public bool ShowOnlyModifiers { get; set; }
     }
 }

--- a/src/Carnac.Logic/ShortcutAccumulator.cs
+++ b/src/Carnac.Logic/ShortcutAccumulator.cs
@@ -88,7 +88,7 @@ namespace Carnac.Logic
             if (HasCompletedValue)
                 throw new InvalidOperationException();
 
-            messages = new[] { new Message(Keys, shortcut) };
+            messages = new[] { new Message(Keys, shortcut, true) };
             HasCompletedValue = true;
         }
 

--- a/src/Carnac/UI/PreferencesView.xaml
+++ b/src/Carnac/UI/PreferencesView.xaml
@@ -138,9 +138,12 @@
                         </ui:PreferencesField>
 
                         <ui:PreferencesField Header="Shortcuts Only">
-                            <CheckBox IsChecked="{Binding Settings.DetectShortcutsOnly}" />
+                            <CheckBox IsChecked="{Binding Settings.DetectShortcutsOnly}" Content="shows only keys which are listed in keymaps folder" />
                         </ui:PreferencesField>
-                        <ui:PreferencesField Header="Show Application Icon">
+						<ui:PreferencesField Header="Show Only Modifiers">
+							<CheckBox IsChecked="{Binding Settings.ShowOnlyModifiers}" Content="shows only keys which have ctrl, shift, alt or windows" />
+						</ui:PreferencesField>
+						<ui:PreferencesField Header="Show Application Icon">
                             <CheckBox IsChecked="{Binding Settings.ShowApplicationIcon}" />
                         </ui:PreferencesField>
                     </StackPanel>


### PR DESCRIPTION
Fixed shortcutOnly to work only with keymaps file. Maybe shortcutOnly should be renamed or better explained? This is a rework and split into smaller commit of #151 and should resolve issue #94.

After looking into the code as I understand it the show only shortcuts was meant to only display key pressed which are listed in the keymaps yaml files and it is per process. The naming is misleading.
As evidenced by issue #94

But in the process of adding the merge function and reusing the Message(IEnumerable keys, KeyShortcut shortcut) constructor. All the merged text and x times got a isShortcut=true.
Therefore in the current state Only Shortcut shows everything except modifier keys without keympas file and individual characters. By adding a third argument which is only passed from the ShortcutAccumulator the original function is restored.

But this does not solve the problem to have a feature to only show "shortcut keys" meaning any combination of alt,ctrl,shift, windows keys. Those are also called modifiers keys. So I added an option to only display modifiers keys throughout any process.
