### PR TITLE
Support showing ctrl, alt, win keys pressed down without any other key

### DIFF
--- a/src/Carnac.Logic/KeyMonitor/InterceptKeys.cs
+++ b/src/Carnac.Logic/KeyMonitor/InterceptKeys.cs
@@ -62,6 +62,7 @@ namespace Carnac.Logic.KeyMonitor
             bool keyUp = wParam == (IntPtr)Win32Methods.WM_KEYUP;
             int vkCode = Marshal.ReadInt32(lParam);
             var key = (Keys)vkCode;
+
             //http://msdn.microsoft.com/en-us/library/windows/desktop/ms646286(v=vs.85).aspx
             if (key != Keys.RMenu && key != Keys.LMenu && wParam == (IntPtr)Win32Methods.WM_SYSKEYDOWN)
             {
@@ -72,6 +73,10 @@ namespace Carnac.Logic.KeyMonitor
             {
                 alt = true;
                 keyUp = true;
+            }
+            if (wParam == (IntPtr)Win32Methods.WM_SYSKEYDOWN && key == Keys.LMenu)
+            {
+                keyDown = true;
             }
 
             return new InterceptKeyEventArgs(

--- a/src/Carnac.Logic/KeyProvider.cs
+++ b/src/Carnac.Logic/KeyProvider.cs
@@ -20,7 +20,7 @@ namespace Carnac.Logic
         readonly IPasswordModeService passwordModeService;
         readonly IDesktopLockEventService desktopLockEventService;
 
-        private readonly IList<Keys> modifierKeys =
+        private static readonly IList<Keys> modifierKeys =
             new List<Keys>
                 {
                     Keys.LControlKey,
@@ -68,7 +68,7 @@ namespace Carnac.Logic
 
                 var keyStreamSubsription = interceptKeysSource.GetKeyStream()
                     .Select(DetectWindowsKey)
-                    .Where(k => !IsModifierKeyPress(k) && k.KeyDirection == KeyDirection.Down)
+                    .Where(k =>  k.KeyDirection == KeyDirection.Down)
                     .Select(ToCarnacKeyPress)
                     .Where(keypress => keypress != null)
                     .Where(k => !passwordModeService.CheckPasswordMode(k.InterceptKeyEventArgs))
@@ -91,7 +91,7 @@ namespace Carnac.Logic
             return interceptKeyEventArgs;
         }
 
-        bool IsModifierKeyPress(InterceptKeyEventArgs interceptKeyEventArgs)
+        public static bool IsModifierKeyPress(InterceptKeyEventArgs interceptKeyEventArgs)
         {
             return modifierKeys.Contains(interceptKeyEventArgs.Key);
         }
@@ -123,6 +123,15 @@ namespace Carnac.Logic
             var controlPressed = interceptKeyEventArgs.ControlPressed;
             var altPressed = interceptKeyEventArgs.AltPressed;
             var shiftPressed = interceptKeyEventArgs.ShiftPressed;
+
+            if (IsModifierKeyPress(interceptKeyEventArgs))
+            {
+                controlPressed = false;
+                altPressed = false;
+                shiftPressed = false;
+                isWinKeyPressed = false;
+            }
+
             if (controlPressed)
                 yield return "Ctrl";
             if (altPressed)

--- a/src/Carnac.Logic/Models/Message.cs
+++ b/src/Carnac.Logic/Models/Message.cs
@@ -13,7 +13,6 @@ namespace Carnac.Logic.Models
         readonly string processName;
         readonly ImageSource processIcon;
         readonly string shortcutName;
-        readonly bool canBeMerged;
         readonly bool isShortcut;
         readonly bool isDeleting;
         readonly DateTime lastMessage;
@@ -29,7 +28,6 @@ namespace Carnac.Logic.Models
         {
             processName = key.Process.ProcessName;
             processIcon = key.Process.ProcessIcon;
-            canBeMerged = !key.HasModifierPressed;
 
             keys = new ReadOnlyCollection<KeyPress>(new[] { key });
             textCollection = new ReadOnlyCollection<string>(CreateTextSequence(key).ToArray());
@@ -49,7 +47,6 @@ namespace Carnac.Logic.Models
             processIcon = allKeys.First().Process.ProcessIcon;
             shortcutName = shortcut.Name;
             isShortcut = true;
-            canBeMerged = false;
 
             this.keys = new ReadOnlyCollection<KeyPress>(allKeys);
 
@@ -63,7 +60,6 @@ namespace Carnac.Logic.Models
             : this(initial.keys.Concat(appended.keys), new KeyShortcut(initial.ShortcutName))
         {
             previous = initial;
-            canBeMerged = true;
         }
 
         private Message(Message initial, bool isDeleting)
@@ -74,13 +70,17 @@ namespace Carnac.Logic.Models
             lastMessage = initial.lastMessage;
         }
 
+        private Message(Message initial, Message replacer, bool replace)
+            : this(replacer.keys, new KeyShortcut(replacer.ShortcutName))
+        {
+            previous = initial;
+         }
+
         public string ProcessName { get { return processName; } }
 
         public ImageSource ProcessIcon { get { return processIcon; } }
 
         public string ShortcutName { get { return shortcutName; } }
-
-        public bool CanBeMerged { get { return canBeMerged; } }
 
         public bool IsShortcut { get { return isShortcut; } }
 
@@ -97,21 +97,35 @@ namespace Carnac.Logic.Models
             return new Message(this, other);
         }
 
-        static readonly TimeSpan OneSecond = TimeSpan.FromSeconds(1);
+        public Message Replace(Message newMessage)
+        {
+            return new Message(this, newMessage, true);
+        }
+
+    static readonly TimeSpan OneSecond = TimeSpan.FromSeconds(1);
 
         public static Message MergeIfNeeded(Message previousMessage, Message newMessage)
         {
-            return ShouldCreateNewMessage(previousMessage, newMessage)
-                ? newMessage
-                : previousMessage.Merge(newMessage);
+            // replace key was after standalone modifier keypress, replace by new Message
+            if (previousMessage.keys != null && KeyProvider.IsModifierKeyPress(previousMessage.keys[0].InterceptKeyEventArgs))
+            {
+                return previousMessage.Replace(newMessage);
+            }
+
+            if (ShouldCreateNewMessage(previousMessage, newMessage))
+            {
+                return newMessage;
+            }
+            return previousMessage.Merge(newMessage);
         }
 
         static bool ShouldCreateNewMessage(Message previous, Message current)
         {
             return previous.ProcessName != current.ProcessName ||
                    current.LastMessage.Subtract(previous.LastMessage) > OneSecond ||
-                   !previous.CanBeMerged ||
-                   !current.CanBeMerged;
+                   KeyProvider.IsModifierKeyPress(current.keys[0].InterceptKeyEventArgs) ||
+                   // accumulate also same modifier shortcuts
+                   (previous.keys[0].HasModifierPressed && !previous.keys[0].Input.SequenceEqual(current.keys[0].Input));
         }
 
         public Message FadeOut()
@@ -204,7 +218,6 @@ namespace Carnac.Logic.Models
                 && string.Equals(processName, other.processName)
                 && Equals(processIcon, other.processIcon)
                 && string.Equals(shortcutName, other.shortcutName)
-                && canBeMerged.Equals(other.canBeMerged)
                 && isShortcut.Equals(other.isShortcut)
                 && isDeleting.Equals(other.isDeleting)
                 && lastMessage.Equals(other.lastMessage);
@@ -227,7 +240,6 @@ namespace Carnac.Logic.Models
                 hashCode = (hashCode * 397) ^ (processName != null ? processName.GetHashCode() : 0);
                 hashCode = (hashCode * 397) ^ (processIcon != null ? processIcon.GetHashCode() : 0);
                 hashCode = (hashCode * 397) ^ (shortcutName != null ? shortcutName.GetHashCode() : 0);
-                hashCode = (hashCode * 397) ^ canBeMerged.GetHashCode();
                 hashCode = (hashCode * 397) ^ isShortcut.GetHashCode();
                 hashCode = (hashCode * 397) ^ isDeleting.GetHashCode();
                 hashCode = (hashCode * 397) ^ lastMessage.GetHashCode();

--- a/src/Carnac.Logic/ReplaceKey.cs
+++ b/src/Carnac.Logic/ReplaceKey.cs
@@ -78,6 +78,10 @@ namespace Carnac.Logic
             {Keys.RShiftKey, "Shift"},
             {Keys.LWin, "Win"},
             {Keys.RWin, "Win"},
+            {Keys.LControlKey, "Ctrl"},
+            {Keys.RControlKey, "Ctrl"},
+            {Keys.Alt, "Alt"},
+            {Keys.LMenu, "Alt"},
         };
 
         public static Keys? ToKey(string keyText)


### PR DESCRIPTION
- Removed filtering of modifierkey to allow to handle them in ToInputs.
- Filtered triggering of modifier display for modifierkeys themselves in
ToInputs.
- Exposed IsModifierKeyPress as static to be used in KeyPress and
Messages.
- KeyPress.HasModifierPress returns false if key is a modifierkey itself
(allow the merging in Message).
- Message disable repeat counting incrementing for modifierkeys
themself, but still handling their repeat, in order for them to keep
showing while keydown.

This should partially solve issue #154 
Note sure about the sticky key part on mac.