### PR TITLE
Support to show  keyboard keys based on locales

### DIFF
--- a/src/Carnac.Logic/KeyProvider.cs
+++ b/src/Carnac.Logic/KeyProvider.cs
@@ -136,22 +136,11 @@ namespace Carnac.Logic
                 if (shiftPressed)
                     yield return "Shift";
 
-                yield return interceptKeyEventArgs.Key.Sanitise();
+                yield return interceptKeyEventArgs.Key.SanitiseLower();
             }
             else
             {
-                string input;
-                var shiftModifiesInput = interceptKeyEventArgs.Key.SanitiseShift(out input);
-
-                if (!isLetter && !shiftModifiesInput && shiftPressed)
-                    yield return "Shift";
-
-                if (interceptKeyEventArgs.ShiftPressed && shiftModifiesInput)
-                    yield return input;
-                else if (isLetter && !interceptKeyEventArgs.ShiftPressed)
-                    yield return interceptKeyEventArgs.Key.ToString().ToLower();
-                else
-                    yield return interceptKeyEventArgs.Key.Sanitise();
+                yield return interceptKeyEventArgs.Key.Sanitise();
             }
         }
 

--- a/src/Carnac.Logic/ReplaceKey.cs
+++ b/src/Carnac.Logic/ReplaceKey.cs
@@ -1,6 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using System.Text;
 using System.Windows.Forms;
+using System.Windows.Input;
 
 namespace Carnac.Logic
 {
@@ -80,6 +83,7 @@ namespace Carnac.Logic
             {Keys.RWin, "Win"},
         };
 
+        // kept to continue to support keymaps parsing
         public static Keys? ToKey(string keyText)
         {
             foreach (var shiftReplacement in ShiftReplacements)
@@ -99,21 +103,51 @@ namespace Carnac.Logic
             return null;
         }
 
-        public static string Sanitise(this Keys key)
+        // new implementation of sanitize to support locals
+        // https://stackoverflow.com/questions/318777/c-sharp-how-to-translate-virtual-keycode-to-char
+        static public string KeyCodeToUnicode(Keys key, bool lowerOnly = false)
         {
-            return Replacements.ContainsKey(key) ? Replacements[key] : string.Format(key.ToString());
-        }
-
-        public static bool SanitiseShift(this Keys key, out string sanitisedKeyInput)
-        {
-            if (ShiftReplacements.ContainsKey(key))
+            byte[] keyboardState = new byte[255];
+            if (!lowerOnly)
             {
-                sanitisedKeyInput = ShiftReplacements[key];
-                return true;
+                bool keyboardStateStatus = GetKeyboardState(keyboardState);
+                if (!keyboardStateStatus)
+                {
+                    return "";
+                }
             }
 
-            sanitisedKeyInput = key.Sanitise();
-            return false;
+            uint virtualKeyCode = (uint)key;
+            uint scanCode = MapVirtualKey(virtualKeyCode, 0);
+            IntPtr inputLocaleIdentifier = GetKeyboardLayout(0);
+
+            StringBuilder result = new StringBuilder();
+            ToUnicodeEx(virtualKeyCode, scanCode, keyboardState, result, (int)5, (uint)0, inputLocaleIdentifier);
+
+            return result.ToString();
         }
+
+        [DllImport("user32.dll")]
+        static extern bool GetKeyboardState(byte[] lpKeyState);
+
+        [DllImport("user32.dll")]
+        static extern uint MapVirtualKey(uint uCode, uint uMapType);
+
+        [DllImport("user32.dll")]
+        static extern IntPtr GetKeyboardLayout(uint idThread);
+
+        [DllImport("user32.dll")]
+        static extern int ToUnicodeEx(uint wVirtKey, uint wScanCode, byte[] lpKeyState, [Out, MarshalAs(UnmanagedType.LPWStr)] StringBuilder pwszBuff, int cchBuff, uint wFlags, IntPtr dwhkl);
+
+        public static string Sanitise(this Keys key)
+        {
+            return KeyCodeToUnicode(key);
+        }
+
+        public static string SanitiseLower(this Keys key)
+        {
+            return KeyCodeToUnicode(key, true);
+        }
+
     }
 }


### PR DESCRIPTION
This fixes partially issue #110 and #65. 

Keys are now showed after transforming them with win32 KeyCodeToUnicode.
If a ctrl or alt is used it defaults to the lowercase default letter => shortcut
If shift is pushed without ctrl or alt it shows directly the mapped character, as was handled before with the hardcoded list, but now it is locale specific and automatic.

However there are some improvements which could be added:
- correct handling of dead keys
- Keymaps parsing still uses the hardcoded values.
- alt-gr shows as ctrl + alt + base key instead of special character
