### PR TITLE
Added option to allow the space character to show as ␣

### DIFF
--- a/src/Carnac.Logic/Models/PopupSettings.cs
+++ b/src/Carnac.Logic/Models/PopupSettings.cs
@@ -89,5 +89,6 @@ namespace Carnac.Logic.Models
         public bool ShowApplicationIcon { get; set; }
         public bool SettingsConfigured { get; set; }
         public bool ShowOnlyModifiers { get; set; }
+        public bool ShowSpaceAsIcon { get; set; }
     }
 }

--- a/src/Carnac/UI/KeyShowView.xaml
+++ b/src/Carnac/UI/KeyShowView.xaml
@@ -15,7 +15,7 @@
                 <componentModel:SortDescription Direction="Descending" PropertyName="LastMessage" />
             </CollectionViewSource.SortDescriptions>
         </CollectionViewSource>
-        <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
+        <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter"/>
 
         <DrawingBrush x:Key="Layer1" Stretch="Uniform">
             <DrawingBrush.Drawing>
@@ -24,36 +24,31 @@
                         <GeometryDrawing
                             Geometry="F1 M 47.5543,45.9331C 55.3596,51.2598 64.0063,55.5305 82.0276,47.9798L 73.1409,79.0625C 55.1236,86.6091 46.4849,82.3212 38.6889,76.9638L 47.5543,45.9331 Z ">
                             <GeometryDrawing.Brush>
-                                <SolidColorBrush
-                                    Color="{Binding DataContext.Settings.ItemBackgroundColor, Source={x:Reference This}}" />
+                                <SolidColorBrush Color="{Binding DataContext.Settings.ItemBackgroundColor, Source={x:Reference This}}" />
                             </GeometryDrawing.Brush>
                         </GeometryDrawing>
                         <GeometryDrawing
                             Geometry="F1 M 44.4637,37.2977C 36.6704,31.9844 28.0211,27.7483 10.0384,35.2817L 18.9517,4.06303C 36.9371,-3.47164 45.5784,0.796367 53.3651,6.13768L 44.4637,37.2977 Z ">
                             <GeometryDrawing.Brush>
-                                <SolidColorBrush
-                                    Color="{Binding DataContext.Settings.ItemBackgroundColor, Source={x:Reference This}}" />
+                                <SolidColorBrush Color="{Binding DataContext.Settings.ItemBackgroundColor, Source={x:Reference This}}" />
                             </GeometryDrawing.Brush>
                         </GeometryDrawing>
                         <GeometryDrawing
                             Geometry="F1 M 0.92133,71.12C 0.842667,71.1506 0.753331,71.1746 0.663996,71.1746C 0.294662,71.172 -0.00267029,70.8653 0,70.492C 0.00133228,70.4267 0.00933266,70.3653 0.0266666,70.308L 8.49333,40.688C 26.4773,33.1546 35.1267,37.3907 42.9187,42.7013L 34.0587,73.7133C 26.4587,68.5 18.0453,64.3106 0.92133,71.12 Z ">
                             <GeometryDrawing.Brush>
-                                <SolidColorBrush
-                                    Color="{Binding DataContext.Settings.ItemBackgroundColor, Source={x:Reference This}}" />
+                                <SolidColorBrush Color="{Binding DataContext.Settings.ItemBackgroundColor, Source={x:Reference This}}" />
                             </GeometryDrawing.Brush>
                         </GeometryDrawing>
                         <GeometryDrawing
                             Geometry="F1 M 92.0659,12.8218L 83.5712,42.5752C 65.5512,50.1245 56.9045,45.8551 49.1005,40.5245L 57.9939,9.38719C 65.6059,14.6192 74.0219,18.8312 91.1819,12.0032C 91.2592,11.9739 91.3432,11.9578 91.4325,11.9578C 91.8032,11.9605 92.0992,12.2671 92.0952,12.6405C 92.0939,12.7032 92.0819,12.7645 92.0659,12.8218 Z ">
                             <GeometryDrawing.Brush>
-                                <SolidColorBrush
-                                    Color="{Binding DataContext.Settings.ItemBackgroundColor, Source={x:Reference This}}" />
+                                <SolidColorBrush Color="{Binding DataContext.Settings.ItemBackgroundColor, Source={x:Reference This}}" />
                             </GeometryDrawing.Brush>
                         </GeometryDrawing>
                         <GeometryDrawing
                             Geometry="F1 M 86.1499,73.521C 86.1499,73.165 86.0499,72.9077 85.8499,72.7477C 85.6245,72.565 85.2419,72.4743 84.7045,72.4743L 83.9365,72.4743L 83.9365,74.589L 84.8672,74.589C 85.7232,74.589 86.1499,74.2331 86.1499,73.521 Z M 87.3472,77.9357L 86.2925,77.9357L 85.6165,76.445C 85.2739,75.6984 84.9032,75.3263 84.5099,75.3263L 83.9365,75.3263L 83.9365,77.9357L 83.0645,77.9357L 83.0645,71.7237L 84.8152,71.7237C 85.5872,71.7237 86.1739,71.8984 86.5725,72.245C 86.9112,72.545 87.0805,72.9357 87.0805,73.417C 87.0805,73.8423 86.9432,74.2063 86.6685,74.505C 86.3925,74.805 86.0045,75.005 85.5059,75.109L 85.5059,75.1357C 85.8525,75.2144 86.1952,75.597 86.5339,76.281M 89.2819,74.8957C 89.2819,73.6664 88.8645,72.6437 88.0312,71.8237C 87.1979,71.0024 86.1819,70.5917 84.9845,70.5917C 83.7432,70.5917 82.7139,71.005 81.8952,71.8317C 81.0765,72.6597 80.6685,73.6797 80.6685,74.8957C 80.6685,76.133 81.0912,77.165 81.9379,77.9944C 82.7672,78.8103 83.7832,79.2184 84.9845,79.2184C 86.1739,79.2184 87.1872,78.805 88.0245,77.9784C 88.8619,77.1517 89.2819,76.1237 89.2819,74.8957 Z M 89.8672,74.8703C 89.8672,76.237 89.3952,77.385 88.4525,78.3171C 87.5072,79.2477 86.3432,79.7144 84.9579,79.7144C 83.5619,79.7144 82.4005,79.2597 81.4779,78.3517C 80.5565,77.445 80.0952,76.297 80.0952,74.909C 80.0952,73.5464 80.5645,72.3957 81.5019,71.461C 82.4392,70.5263 83.6045,70.057 84.9979,70.057C 86.3645,70.057 87.5125,70.505 88.4419,71.3984C 89.3925,72.3157 89.8672,73.4717 89.8672,74.8703 Z ">
                             <GeometryDrawing.Brush>
-                                <SolidColorBrush
-                                    Color="{Binding DataContext.Settings.ItemBackgroundColor, Source={x:Reference This}}" />
+                                <SolidColorBrush Color="{Binding DataContext.Settings.ItemBackgroundColor, Source={x:Reference This}}" />
                             </GeometryDrawing.Brush>
                         </GeometryDrawing>
                     </DrawingGroup.Children>
@@ -77,8 +72,7 @@
                         Opacity="{Binding DataContext.Settings.ItemOpacity, Source={x:Reference This}}"
                         IsHitTestVisible="True" Focusable="True" BorderThickness="4" CornerRadius="15" Padding="3">
                     <Border.Background>
-                        <SolidColorBrush
-                            Color="{Binding DataContext.Settings.ItemBackgroundColor, Source={x:Reference This}}" />
+                        <SolidColorBrush Color="{Binding DataContext.Settings.ItemBackgroundColor, Source={x:Reference This}}" />
                     </Border.Background>
                     <Border.Style>
                         <Style>
@@ -97,142 +91,116 @@
                         </Style>
                     </Border.Style>
                     <Border.LayoutTransform>
-                        <ScaleTransform
-                            ScaleY="{Binding DataContext.Settings.ScaleTransform, Source={x:Reference This}}" />
+                        <ScaleTransform ScaleY="{Binding DataContext.Settings.ScaleTransform, Source={x:Reference This}}" />
                     </Border.LayoutTransform>
                     <StackPanel Orientation="Horizontal">
-                        <Image Margin="3" Width="20" Height="20"
-                               Visibility="{Binding DataContext.Settings.ShowApplicationIcon,Source={x:Reference This},
-                            Converter={StaticResource BooleanToVisibilityConverter}}"
-                               Source="{Binding ProcessIcon, Mode=OneWay}" />
+                        <Image Margin="3" Width="20" Height="20"  Visibility="{Binding DataContext.Settings.ShowApplicationIcon,Source={x:Reference This},
+                            Converter={StaticResource BooleanToVisibilityConverter}}" Source="{Binding ProcessIcon, Mode=OneWay}" />
                         <ListBox MaxWidth="{Binding DataContext.Settings.ItemMaxWidth, Source={x:Reference This}}"
-                                 HorizontalAlignment="Stretch" VerticalContentAlignment="Center"
-                                 ItemsSource="{Binding Text, Mode=OneWay}"
-                                 FontWeight="Bold" Focusable="False" BorderBrush="{x:Null}"
-                                 ScrollViewer.HorizontalScrollBarVisibility="Disabled" IsHitTestVisible="False">
-                            <ListBox.Background>
-                                <SolidColorBrush
-                                    Color="{Binding DataContext.Settings.ItemBackgroundColor, Source={x:Reference This}}" />
-                            </ListBox.Background>
-                            <ListBox.Foreground>
-                                <SolidColorBrush
-                                    Color="{Binding DataContext.Settings.FontColor, Source={x:Reference This}}" />
-                            </ListBox.Foreground>
-                            <ListBox.ItemsPanel>
-                                <ItemsPanelTemplate>
-                                    <WrapPanel />
-                                </ItemsPanelTemplate>
-                            </ListBox.ItemsPanel>
-                            <ListBox.ItemContainerStyle>
-                                <Style TargetType="ListBoxItem">
-                                    <Setter Property="Padding" Value="0" />
-                                    <Setter Property="Margin" Value="0" />
-                                </Style>
-                            </ListBox.ItemContainerStyle>
-                            <ListBox.ItemTemplate>
-                                <DataTemplate>
-                                    <StackPanel Orientation="Horizontal">
-                                        <Border x:Name="KeyCapBorder" Margin="2" Visibility="Collapsed"
-                                                CornerRadius="5"
-                                                Padding="2,5">
-                                            <Border.Background>
-                                                <SolidColorBrush
-                                                    Color="{Binding DataContext.Settings.FontColor, Source={x:Reference This}}" />
-                                            </Border.Background>
-                                            <StackPanel Orientation="Horizontal">
-                                                <Rectangle x:Name="icon" VerticalAlignment="Center" />
-                                                <TextBlock x:Name="KeyCap" Text="{Binding  }">
-                                                    <TextBlock.Foreground>
-                                                        <SolidColorBrush
-                                                            Color="{Binding DataContext.Settings.ItemBackgroundColor, Source={x:Reference This}}" />
-                                                    </TextBlock.Foreground>
-                                                </TextBlock>
-                                            </StackPanel>
-                                        </Border>
+                             HorizontalAlignment="Stretch" VerticalContentAlignment="Center" ItemsSource="{Binding Text, Mode=OneWay}"
+                             FontWeight="Bold" Focusable="False" BorderBrush="{x:Null}"
+                             ScrollViewer.HorizontalScrollBarVisibility="Disabled" IsHitTestVisible="False">
+                        <ListBox.Background>
+                            <SolidColorBrush Color="{Binding DataContext.Settings.ItemBackgroundColor, Source={x:Reference This}}" />
+                        </ListBox.Background>
+                        <ListBox.Foreground>
+                            <SolidColorBrush Color="{Binding DataContext.Settings.FontColor, Source={x:Reference This}}" />
+                        </ListBox.Foreground>
+                        <ListBox.ItemsPanel>
+                            <ItemsPanelTemplate>
+                                <WrapPanel />
+                            </ItemsPanelTemplate>
+                        </ListBox.ItemsPanel>
+                        <ListBox.ItemContainerStyle>
+                            <Style TargetType="ListBoxItem">
+                                <Setter Property="Padding" Value="0" />
+                                <Setter Property="Margin" Value="0" />
+                            </Style>
+                        </ListBox.ItemContainerStyle>
+                        <ListBox.ItemTemplate>
+                            <DataTemplate>
+                                <StackPanel Orientation="Horizontal">
+                                    <Border x:Name="KeyCapBorder" Margin="2" Visibility="Collapsed" CornerRadius="5"
+                                            Padding="2,5">
+                                        <Border.Background>
+                                            <SolidColorBrush Color="{Binding DataContext.Settings.FontColor, Source={x:Reference This}}" />
+                                        </Border.Background>
+                                        <StackPanel Orientation="Horizontal">
+                                            <Rectangle x:Name="icon" VerticalAlignment="Center" />
+                                            <TextBlock x:Name="KeyCap" Text="{Binding  }">
+                                                <TextBlock.Foreground>
+                                                    <SolidColorBrush Color="{Binding DataContext.Settings.ItemBackgroundColor, Source={x:Reference This}}" />
+                                                </TextBlock.Foreground>
+                                            </TextBlock>
+                                        </StackPanel>
+                                    </Border>
 
+                          
+                                    <TextBlock x:Name="regular" Margin="0" VerticalAlignment="Center" Text="{Binding }"
+                                               Padding="0" />
+                                </StackPanel>
+                                <DataTemplate.Triggers>
+                                    <MultiDataTrigger>
+                                        <MultiDataTrigger.Conditions>
+                                            <Condition Binding="{Binding .}" Value=" " />
+                                            <Condition
+                                                Binding="{Binding DataContext.Settings.ShowSpaceAsIcon, RelativeSource={RelativeSource AncestorType=Window}}"
+                                                Value="True" />
+                                        </MultiDataTrigger.Conditions>
+                                        <Setter TargetName="regular" Property="TextBlock.Text" Value="␣" />
+                                    </MultiDataTrigger>
+                                    <MultiDataTrigger>
+                                        <MultiDataTrigger.Conditions>
+                                            <Condition Binding="{Binding .}" Value=" " />
+                                            <Condition
+                                                Binding="{Binding DataContext.Settings.ShowSpaceAsIcon, RelativeSource={RelativeSource AncestorType=Window}}"
+                                                Value="False" />
+                                        </MultiDataTrigger.Conditions>
+                                        <Setter TargetName="regular" Property="Control.MinWidth" Value="10"/>
+                                    </MultiDataTrigger>
+                                    <DataTrigger Value="Return" Binding="{Binding .}">
+                                        <Setter TargetName="KeyCapBorder" Property="Control.Visibility" Value="Visible" />
+                                        <Setter TargetName="KeyCap" Property="Text" Value="↵" />
+                                        <Setter TargetName="regular" Property="Control.Visibility" Value="Collapsed" />
+                                    </DataTrigger>
 
-                                        <TextBlock x:Name="regular" Margin="0" VerticalAlignment="Center"
-                                                   Text="{Binding }"
-                                                   Padding="0" />
-                                    </StackPanel>
+                                    <DataTrigger Value="Back" Binding="{Binding .}">
+                                        <Setter TargetName="KeyCapBorder" Property="Control.Visibility" Value="Visible" />
+                                        <Setter TargetName="regular" Property="Control.Visibility" Value="Collapsed" />
+                                    </DataTrigger>
 
-                                    <DataTemplate.Triggers>
-                                        <MultiDataTrigger>
-                                            <MultiDataTrigger.Conditions>
-                                                <Condition Binding="{Binding .}" Value=" " />
-                                                <Condition
-                                                    Binding="{Binding DataContext.Settings.ShowSpaceAsIcon, RelativeSource={RelativeSource AncestorType=Window}}"
-                                                    Value="True" />
-                                            </MultiDataTrigger.Conditions>
-                                            <Setter TargetName="regular" Property="TextBlock.Text" Value="␣" />
-                                        </MultiDataTrigger>
-                                        <MultiDataTrigger>
-                                            <MultiDataTrigger.Conditions>
-                                                <Condition Binding="{Binding .}" Value=" " />
-                                                <Condition
-                                                    Binding="{Binding DataContext.Settings.ShowSpaceAsIcon, RelativeSource={RelativeSource AncestorType=Window}}"
-                                                    Value="False" />
-                                            </MultiDataTrigger.Conditions>
-                                            <Setter TargetName="regular" Property="Control.MinWidth" Value="10"/>
-                                        </MultiDataTrigger>
+                                    <DataTrigger Value="Escape" Binding="{Binding .}">
+                                        <Setter TargetName="KeyCapBorder" Property="Control.Visibility" Value="Visible" />
+                                        <Setter TargetName="regular" Property="Control.Visibility" Value="Collapsed" />
+                                    </DataTrigger>
 
-                                        <DataTrigger Value="Return" Binding="{Binding .}">
-                                            <Setter TargetName="KeyCapBorder" Property="Control.Visibility"
-                                                    Value="Visible" />
-                                            <Setter TargetName="KeyCap" Property="Text" Value="↵" />
-                                            <Setter TargetName="regular" Property="Control.Visibility"
-                                                    Value="Collapsed" />
-                                        </DataTrigger>
+                                    <DataTrigger Value="Alt" Binding="{Binding .}">
+                                        <Setter TargetName="KeyCapBorder" Property="Control.Visibility" Value="Visible" />
+                                        <Setter TargetName="regular" Property="Control.Visibility" Value="Collapsed" />
+                                    </DataTrigger>
+                                    <DataTrigger Value="Ctrl" Binding="{Binding .}">
+                                        <Setter TargetName="KeyCapBorder" Property="Control.Visibility" Value="Visible" />
+                                        <Setter TargetName="regular" Property="Control.Visibility" Value="Collapsed" />
+                                    </DataTrigger>
 
-                                        <DataTrigger Value="Back" Binding="{Binding .}">
-                                            <Setter TargetName="KeyCapBorder" Property="Control.Visibility"
-                                                    Value="Visible" />
-                                            <Setter TargetName="regular" Property="Control.Visibility"
-                                                    Value="Collapsed" />
-                                        </DataTrigger>
+                                    <DataTrigger Value="Shift" Binding="{Binding .}">
+                                        <Setter TargetName="KeyCapBorder" Property="Control.Visibility" Value="Visible" />
+                                        <Setter TargetName="regular" Property="Control.Visibility" Value="Collapsed" />
+                                    </DataTrigger>
 
-                                        <DataTrigger Value="Escape" Binding="{Binding .}">
-                                            <Setter TargetName="KeyCapBorder" Property="Control.Visibility"
-                                                    Value="Visible" />
-                                            <Setter TargetName="regular" Property="Control.Visibility"
-                                                    Value="Collapsed" />
-                                        </DataTrigger>
-
-                                        <DataTrigger Value="Alt" Binding="{Binding .}">
-                                            <Setter TargetName="KeyCapBorder" Property="Control.Visibility"
-                                                    Value="Visible" />
-                                            <Setter TargetName="regular" Property="Control.Visibility"
-                                                    Value="Collapsed" />
-                                        </DataTrigger>
-                                        <DataTrigger Value="Ctrl" Binding="{Binding .}">
-                                            <Setter TargetName="KeyCapBorder" Property="Control.Visibility"
-                                                    Value="Visible" />
-                                            <Setter TargetName="regular" Property="Control.Visibility"
-                                                    Value="Collapsed" />
-                                        </DataTrigger>
-
-                                        <DataTrigger Value="Shift" Binding="{Binding .}">
-                                            <Setter TargetName="KeyCapBorder" Property="Control.Visibility"
-                                                    Value="Visible" />
-                                            <Setter TargetName="regular" Property="Control.Visibility"
-                                                    Value="Collapsed" />
-                                        </DataTrigger>
-
-                                        <DataTrigger Value="Win" Binding="{Binding .}">
-                                            <Setter TargetName="regular" Property="Control.Visibility"
-                                                    Value="Collapsed" />
-                                            <Setter TargetName="KeyCapBorder" Property="Control.Visibility"
-                                                    Value="Visible" />
-                                            <Setter TargetName="KeyCap" Property="Control.Visibility" Value="Collapsed" />
-                                            <Setter TargetName="icon" Property="Rectangle.Fill"
-                                                    Value="{StaticResource Layer1}" />
-                                            <Setter TargetName="icon" Property="Rectangle.Width" Value="50" />
-                                            <Setter TargetName="icon" Property="Rectangle.Height" Value="50" />
-                                        </DataTrigger>
-                                    </DataTemplate.Triggers>
-                                </DataTemplate>
-                            </ListBox.ItemTemplate>
-                        </ListBox>
+                                    <DataTrigger Value="Win" Binding="{Binding .}">
+                                        <Setter TargetName="regular" Property="Control.Visibility" Value="Collapsed" />
+                                        <Setter TargetName="KeyCapBorder" Property="Control.Visibility" Value="Visible" />
+                                        <Setter TargetName="KeyCap" Property="Control.Visibility" Value="Collapsed" />
+                                        <Setter TargetName="icon" Property="Rectangle.Fill"
+                                                Value="{StaticResource Layer1}" />
+                                        <Setter TargetName="icon" Property="Rectangle.Width" Value="50" />
+                                        <Setter TargetName="icon" Property="Rectangle.Height" Value="50" />
+                                    </DataTrigger>
+                                </DataTemplate.Triggers>
+                            </DataTemplate>
+                        </ListBox.ItemTemplate>
+                    </ListBox>
                     </StackPanel>
                 </Border>
             </DataTemplate>

--- a/src/Carnac/UI/KeyShowView.xaml
+++ b/src/Carnac/UI/KeyShowView.xaml
@@ -15,7 +15,7 @@
                 <componentModel:SortDescription Direction="Descending" PropertyName="LastMessage" />
             </CollectionViewSource.SortDescriptions>
         </CollectionViewSource>
-        <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter"/>
+        <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
 
         <DrawingBrush x:Key="Layer1" Stretch="Uniform">
             <DrawingBrush.Drawing>
@@ -24,31 +24,36 @@
                         <GeometryDrawing
                             Geometry="F1 M 47.5543,45.9331C 55.3596,51.2598 64.0063,55.5305 82.0276,47.9798L 73.1409,79.0625C 55.1236,86.6091 46.4849,82.3212 38.6889,76.9638L 47.5543,45.9331 Z ">
                             <GeometryDrawing.Brush>
-                                <SolidColorBrush Color="{Binding DataContext.Settings.ItemBackgroundColor, Source={x:Reference This}}" />
+                                <SolidColorBrush
+                                    Color="{Binding DataContext.Settings.ItemBackgroundColor, Source={x:Reference This}}" />
                             </GeometryDrawing.Brush>
                         </GeometryDrawing>
                         <GeometryDrawing
                             Geometry="F1 M 44.4637,37.2977C 36.6704,31.9844 28.0211,27.7483 10.0384,35.2817L 18.9517,4.06303C 36.9371,-3.47164 45.5784,0.796367 53.3651,6.13768L 44.4637,37.2977 Z ">
                             <GeometryDrawing.Brush>
-                                <SolidColorBrush Color="{Binding DataContext.Settings.ItemBackgroundColor, Source={x:Reference This}}" />
+                                <SolidColorBrush
+                                    Color="{Binding DataContext.Settings.ItemBackgroundColor, Source={x:Reference This}}" />
                             </GeometryDrawing.Brush>
                         </GeometryDrawing>
                         <GeometryDrawing
                             Geometry="F1 M 0.92133,71.12C 0.842667,71.1506 0.753331,71.1746 0.663996,71.1746C 0.294662,71.172 -0.00267029,70.8653 0,70.492C 0.00133228,70.4267 0.00933266,70.3653 0.0266666,70.308L 8.49333,40.688C 26.4773,33.1546 35.1267,37.3907 42.9187,42.7013L 34.0587,73.7133C 26.4587,68.5 18.0453,64.3106 0.92133,71.12 Z ">
                             <GeometryDrawing.Brush>
-                                <SolidColorBrush Color="{Binding DataContext.Settings.ItemBackgroundColor, Source={x:Reference This}}" />
+                                <SolidColorBrush
+                                    Color="{Binding DataContext.Settings.ItemBackgroundColor, Source={x:Reference This}}" />
                             </GeometryDrawing.Brush>
                         </GeometryDrawing>
                         <GeometryDrawing
                             Geometry="F1 M 92.0659,12.8218L 83.5712,42.5752C 65.5512,50.1245 56.9045,45.8551 49.1005,40.5245L 57.9939,9.38719C 65.6059,14.6192 74.0219,18.8312 91.1819,12.0032C 91.2592,11.9739 91.3432,11.9578 91.4325,11.9578C 91.8032,11.9605 92.0992,12.2671 92.0952,12.6405C 92.0939,12.7032 92.0819,12.7645 92.0659,12.8218 Z ">
                             <GeometryDrawing.Brush>
-                                <SolidColorBrush Color="{Binding DataContext.Settings.ItemBackgroundColor, Source={x:Reference This}}" />
+                                <SolidColorBrush
+                                    Color="{Binding DataContext.Settings.ItemBackgroundColor, Source={x:Reference This}}" />
                             </GeometryDrawing.Brush>
                         </GeometryDrawing>
                         <GeometryDrawing
                             Geometry="F1 M 86.1499,73.521C 86.1499,73.165 86.0499,72.9077 85.8499,72.7477C 85.6245,72.565 85.2419,72.4743 84.7045,72.4743L 83.9365,72.4743L 83.9365,74.589L 84.8672,74.589C 85.7232,74.589 86.1499,74.2331 86.1499,73.521 Z M 87.3472,77.9357L 86.2925,77.9357L 85.6165,76.445C 85.2739,75.6984 84.9032,75.3263 84.5099,75.3263L 83.9365,75.3263L 83.9365,77.9357L 83.0645,77.9357L 83.0645,71.7237L 84.8152,71.7237C 85.5872,71.7237 86.1739,71.8984 86.5725,72.245C 86.9112,72.545 87.0805,72.9357 87.0805,73.417C 87.0805,73.8423 86.9432,74.2063 86.6685,74.505C 86.3925,74.805 86.0045,75.005 85.5059,75.109L 85.5059,75.1357C 85.8525,75.2144 86.1952,75.597 86.5339,76.281M 89.2819,74.8957C 89.2819,73.6664 88.8645,72.6437 88.0312,71.8237C 87.1979,71.0024 86.1819,70.5917 84.9845,70.5917C 83.7432,70.5917 82.7139,71.005 81.8952,71.8317C 81.0765,72.6597 80.6685,73.6797 80.6685,74.8957C 80.6685,76.133 81.0912,77.165 81.9379,77.9944C 82.7672,78.8103 83.7832,79.2184 84.9845,79.2184C 86.1739,79.2184 87.1872,78.805 88.0245,77.9784C 88.8619,77.1517 89.2819,76.1237 89.2819,74.8957 Z M 89.8672,74.8703C 89.8672,76.237 89.3952,77.385 88.4525,78.3171C 87.5072,79.2477 86.3432,79.7144 84.9579,79.7144C 83.5619,79.7144 82.4005,79.2597 81.4779,78.3517C 80.5565,77.445 80.0952,76.297 80.0952,74.909C 80.0952,73.5464 80.5645,72.3957 81.5019,71.461C 82.4392,70.5263 83.6045,70.057 84.9979,70.057C 86.3645,70.057 87.5125,70.505 88.4419,71.3984C 89.3925,72.3157 89.8672,73.4717 89.8672,74.8703 Z ">
                             <GeometryDrawing.Brush>
-                                <SolidColorBrush Color="{Binding DataContext.Settings.ItemBackgroundColor, Source={x:Reference This}}" />
+                                <SolidColorBrush
+                                    Color="{Binding DataContext.Settings.ItemBackgroundColor, Source={x:Reference This}}" />
                             </GeometryDrawing.Brush>
                         </GeometryDrawing>
                     </DrawingGroup.Children>
@@ -72,7 +77,8 @@
                         Opacity="{Binding DataContext.Settings.ItemOpacity, Source={x:Reference This}}"
                         IsHitTestVisible="True" Focusable="True" BorderThickness="4" CornerRadius="15" Padding="3">
                     <Border.Background>
-                        <SolidColorBrush Color="{Binding DataContext.Settings.ItemBackgroundColor, Source={x:Reference This}}" />
+                        <SolidColorBrush
+                            Color="{Binding DataContext.Settings.ItemBackgroundColor, Source={x:Reference This}}" />
                     </Border.Background>
                     <Border.Style>
                         <Style>
@@ -91,101 +97,142 @@
                         </Style>
                     </Border.Style>
                     <Border.LayoutTransform>
-                        <ScaleTransform ScaleY="{Binding DataContext.Settings.ScaleTransform, Source={x:Reference This}}" />
+                        <ScaleTransform
+                            ScaleY="{Binding DataContext.Settings.ScaleTransform, Source={x:Reference This}}" />
                     </Border.LayoutTransform>
                     <StackPanel Orientation="Horizontal">
-                        <Image Margin="3" Width="20" Height="20"  Visibility="{Binding DataContext.Settings.ShowApplicationIcon,Source={x:Reference This},
-                            Converter={StaticResource BooleanToVisibilityConverter}}" Source="{Binding ProcessIcon, Mode=OneWay}" />
+                        <Image Margin="3" Width="20" Height="20"
+                               Visibility="{Binding DataContext.Settings.ShowApplicationIcon,Source={x:Reference This},
+                            Converter={StaticResource BooleanToVisibilityConverter}}"
+                               Source="{Binding ProcessIcon, Mode=OneWay}" />
                         <ListBox MaxWidth="{Binding DataContext.Settings.ItemMaxWidth, Source={x:Reference This}}"
-                             HorizontalAlignment="Stretch" VerticalContentAlignment="Center" ItemsSource="{Binding Text, Mode=OneWay}"
-                             FontWeight="Bold" Focusable="False" BorderBrush="{x:Null}"
-                             ScrollViewer.HorizontalScrollBarVisibility="Disabled" IsHitTestVisible="False">
-                        <ListBox.Background>
-                            <SolidColorBrush Color="{Binding DataContext.Settings.ItemBackgroundColor, Source={x:Reference This}}" />
-                        </ListBox.Background>
-                        <ListBox.Foreground>
-                            <SolidColorBrush Color="{Binding DataContext.Settings.FontColor, Source={x:Reference This}}" />
-                        </ListBox.Foreground>
-                        <ListBox.ItemsPanel>
-                            <ItemsPanelTemplate>
-                                <WrapPanel />
-                            </ItemsPanelTemplate>
-                        </ListBox.ItemsPanel>
-                        <ListBox.ItemContainerStyle>
-                            <Style TargetType="ListBoxItem">
-                                <Setter Property="Padding" Value="0" />
-                                <Setter Property="Margin" Value="0" />
-                            </Style>
-                        </ListBox.ItemContainerStyle>
-                        <ListBox.ItemTemplate>
-                            <DataTemplate>
-                                <StackPanel Orientation="Horizontal">
-                                    <Border x:Name="KeyCapBorder" Margin="2" Visibility="Collapsed" CornerRadius="5"
-                                            Padding="2,5">
-                                        <Border.Background>
-                                            <SolidColorBrush Color="{Binding DataContext.Settings.FontColor, Source={x:Reference This}}" />
-                                        </Border.Background>
-                                        <StackPanel Orientation="Horizontal">
-                                            <Rectangle x:Name="icon" VerticalAlignment="Center" />
-                                            <TextBlock x:Name="KeyCap" Text="{Binding  }">
-                                                <TextBlock.Foreground>
-                                                    <SolidColorBrush Color="{Binding DataContext.Settings.ItemBackgroundColor, Source={x:Reference This}}" />
-                                                </TextBlock.Foreground>
-                                            </TextBlock>
-                                        </StackPanel>
-                                    </Border>
+                                 HorizontalAlignment="Stretch" VerticalContentAlignment="Center"
+                                 ItemsSource="{Binding Text, Mode=OneWay}"
+                                 FontWeight="Bold" Focusable="False" BorderBrush="{x:Null}"
+                                 ScrollViewer.HorizontalScrollBarVisibility="Disabled" IsHitTestVisible="False">
+                            <ListBox.Background>
+                                <SolidColorBrush
+                                    Color="{Binding DataContext.Settings.ItemBackgroundColor, Source={x:Reference This}}" />
+                            </ListBox.Background>
+                            <ListBox.Foreground>
+                                <SolidColorBrush
+                                    Color="{Binding DataContext.Settings.FontColor, Source={x:Reference This}}" />
+                            </ListBox.Foreground>
+                            <ListBox.ItemsPanel>
+                                <ItemsPanelTemplate>
+                                    <WrapPanel />
+                                </ItemsPanelTemplate>
+                            </ListBox.ItemsPanel>
+                            <ListBox.ItemContainerStyle>
+                                <Style TargetType="ListBoxItem">
+                                    <Setter Property="Padding" Value="0" />
+                                    <Setter Property="Margin" Value="0" />
+                                </Style>
+                            </ListBox.ItemContainerStyle>
+                            <ListBox.ItemTemplate>
+                                <DataTemplate>
+                                    <StackPanel Orientation="Horizontal">
+                                        <Border x:Name="KeyCapBorder" Margin="2" Visibility="Collapsed"
+                                                CornerRadius="5"
+                                                Padding="2,5">
+                                            <Border.Background>
+                                                <SolidColorBrush
+                                                    Color="{Binding DataContext.Settings.FontColor, Source={x:Reference This}}" />
+                                            </Border.Background>
+                                            <StackPanel Orientation="Horizontal">
+                                                <Rectangle x:Name="icon" VerticalAlignment="Center" />
+                                                <TextBlock x:Name="KeyCap" Text="{Binding  }">
+                                                    <TextBlock.Foreground>
+                                                        <SolidColorBrush
+                                                            Color="{Binding DataContext.Settings.ItemBackgroundColor, Source={x:Reference This}}" />
+                                                    </TextBlock.Foreground>
+                                                </TextBlock>
+                                            </StackPanel>
+                                        </Border>
 
-                          
-                                    <TextBlock x:Name="regular" Margin="0" VerticalAlignment="Center" Text="{Binding }"
-                                               Padding="0" />
-                                </StackPanel>
-                                <DataTemplate.Triggers>
-                                    <DataTrigger Value=" " Binding="{Binding .}">
-                                        <Setter TargetName="regular" Property="Control.MinWidth" Value="10" />
-                                    </DataTrigger>
-                                    <DataTrigger Value="Return" Binding="{Binding .}">
-                                        <Setter TargetName="KeyCapBorder" Property="Control.Visibility" Value="Visible" />
-                                        <Setter TargetName="KeyCap" Property="Text" Value="↵" />
-                                        <Setter TargetName="regular" Property="Control.Visibility" Value="Collapsed" />
-                                    </DataTrigger>
 
-                                    <DataTrigger Value="Back" Binding="{Binding .}">
-                                        <Setter TargetName="KeyCapBorder" Property="Control.Visibility" Value="Visible" />
-                                        <Setter TargetName="regular" Property="Control.Visibility" Value="Collapsed" />
-                                    </DataTrigger>
+                                        <TextBlock x:Name="regular" Margin="0" VerticalAlignment="Center"
+                                                   Text="{Binding }"
+                                                   Padding="0" />
+                                    </StackPanel>
 
-                                    <DataTrigger Value="Escape" Binding="{Binding .}">
-                                        <Setter TargetName="KeyCapBorder" Property="Control.Visibility" Value="Visible" />
-                                        <Setter TargetName="regular" Property="Control.Visibility" Value="Collapsed" />
-                                    </DataTrigger>
+                                    <DataTemplate.Triggers>
+                                        <MultiDataTrigger>
+                                            <MultiDataTrigger.Conditions>
+                                                <Condition Binding="{Binding .}" Value=" " />
+                                                <Condition
+                                                    Binding="{Binding DataContext.Settings.ShowSpaceAsIcon, RelativeSource={RelativeSource AncestorType=Window}}"
+                                                    Value="True" />
+                                            </MultiDataTrigger.Conditions>
+                                            <Setter TargetName="regular" Property="TextBlock.Text" Value="␣" />
+                                        </MultiDataTrigger>
+                                        <MultiDataTrigger>
+                                            <MultiDataTrigger.Conditions>
+                                                <Condition Binding="{Binding .}" Value=" " />
+                                                <Condition
+                                                    Binding="{Binding DataContext.Settings.ShowSpaceAsIcon, RelativeSource={RelativeSource AncestorType=Window}}"
+                                                    Value="False" />
+                                            </MultiDataTrigger.Conditions>
+                                            <Setter TargetName="regular" Property="Control.MinWidth" Value="10"/>
+                                        </MultiDataTrigger>
 
-                                    <DataTrigger Value="Alt" Binding="{Binding .}">
-                                        <Setter TargetName="KeyCapBorder" Property="Control.Visibility" Value="Visible" />
-                                        <Setter TargetName="regular" Property="Control.Visibility" Value="Collapsed" />
-                                    </DataTrigger>
-                                    <DataTrigger Value="Ctrl" Binding="{Binding .}">
-                                        <Setter TargetName="KeyCapBorder" Property="Control.Visibility" Value="Visible" />
-                                        <Setter TargetName="regular" Property="Control.Visibility" Value="Collapsed" />
-                                    </DataTrigger>
+                                        <DataTrigger Value="Return" Binding="{Binding .}">
+                                            <Setter TargetName="KeyCapBorder" Property="Control.Visibility"
+                                                    Value="Visible" />
+                                            <Setter TargetName="KeyCap" Property="Text" Value="↵" />
+                                            <Setter TargetName="regular" Property="Control.Visibility"
+                                                    Value="Collapsed" />
+                                        </DataTrigger>
 
-                                    <DataTrigger Value="Shift" Binding="{Binding .}">
-                                        <Setter TargetName="KeyCapBorder" Property="Control.Visibility" Value="Visible" />
-                                        <Setter TargetName="regular" Property="Control.Visibility" Value="Collapsed" />
-                                    </DataTrigger>
+                                        <DataTrigger Value="Back" Binding="{Binding .}">
+                                            <Setter TargetName="KeyCapBorder" Property="Control.Visibility"
+                                                    Value="Visible" />
+                                            <Setter TargetName="regular" Property="Control.Visibility"
+                                                    Value="Collapsed" />
+                                        </DataTrigger>
 
-                                    <DataTrigger Value="Win" Binding="{Binding .}">
-                                        <Setter TargetName="regular" Property="Control.Visibility" Value="Collapsed" />
-                                        <Setter TargetName="KeyCapBorder" Property="Control.Visibility" Value="Visible" />
-                                        <Setter TargetName="KeyCap" Property="Control.Visibility" Value="Collapsed" />
-                                        <Setter TargetName="icon" Property="Rectangle.Fill"
-                                                Value="{StaticResource Layer1}" />
-                                        <Setter TargetName="icon" Property="Rectangle.Width" Value="50" />
-                                        <Setter TargetName="icon" Property="Rectangle.Height" Value="50" />
-                                    </DataTrigger>
-                                </DataTemplate.Triggers>
-                            </DataTemplate>
-                        </ListBox.ItemTemplate>
-                    </ListBox>
+                                        <DataTrigger Value="Escape" Binding="{Binding .}">
+                                            <Setter TargetName="KeyCapBorder" Property="Control.Visibility"
+                                                    Value="Visible" />
+                                            <Setter TargetName="regular" Property="Control.Visibility"
+                                                    Value="Collapsed" />
+                                        </DataTrigger>
+
+                                        <DataTrigger Value="Alt" Binding="{Binding .}">
+                                            <Setter TargetName="KeyCapBorder" Property="Control.Visibility"
+                                                    Value="Visible" />
+                                            <Setter TargetName="regular" Property="Control.Visibility"
+                                                    Value="Collapsed" />
+                                        </DataTrigger>
+                                        <DataTrigger Value="Ctrl" Binding="{Binding .}">
+                                            <Setter TargetName="KeyCapBorder" Property="Control.Visibility"
+                                                    Value="Visible" />
+                                            <Setter TargetName="regular" Property="Control.Visibility"
+                                                    Value="Collapsed" />
+                                        </DataTrigger>
+
+                                        <DataTrigger Value="Shift" Binding="{Binding .}">
+                                            <Setter TargetName="KeyCapBorder" Property="Control.Visibility"
+                                                    Value="Visible" />
+                                            <Setter TargetName="regular" Property="Control.Visibility"
+                                                    Value="Collapsed" />
+                                        </DataTrigger>
+
+                                        <DataTrigger Value="Win" Binding="{Binding .}">
+                                            <Setter TargetName="regular" Property="Control.Visibility"
+                                                    Value="Collapsed" />
+                                            <Setter TargetName="KeyCapBorder" Property="Control.Visibility"
+                                                    Value="Visible" />
+                                            <Setter TargetName="KeyCap" Property="Control.Visibility" Value="Collapsed" />
+                                            <Setter TargetName="icon" Property="Rectangle.Fill"
+                                                    Value="{StaticResource Layer1}" />
+                                            <Setter TargetName="icon" Property="Rectangle.Width" Value="50" />
+                                            <Setter TargetName="icon" Property="Rectangle.Height" Value="50" />
+                                        </DataTrigger>
+                                    </DataTemplate.Triggers>
+                                </DataTemplate>
+                            </ListBox.ItemTemplate>
+                        </ListBox>
                     </StackPanel>
                 </Border>
             </DataTemplate>

--- a/src/Carnac/UI/PreferencesView.xaml
+++ b/src/Carnac/UI/PreferencesView.xaml
@@ -95,7 +95,7 @@
                     </StackPanel>
                 </Grid>
             </TabItem>
-            <TabItem Header="Appearances">
+            <TabItem Header="Appearance">
                 <Grid>
                     <Grid.RowDefinitions>
                         <RowDefinition />
@@ -140,6 +140,7 @@
                               ItemsSource="{Binding AvailableColors}"
                               ItemTemplate="{StaticResource ColourPickerTemplate}" />
                         </ui:PreferencesField>
+                        
                         <ui:PreferencesField Header="Show Space as ␣">
                             <CheckBox IsChecked="{Binding Settings.ShowSpaceAsIcon}" Content="shows space as ' ␣ ' instead of '   '" />
                         </ui:PreferencesField>

--- a/src/Carnac/UI/PreferencesView.xaml
+++ b/src/Carnac/UI/PreferencesView.xaml
@@ -95,7 +95,7 @@
                     </StackPanel>
                 </Grid>
             </TabItem>
-            <TabItem Header="Appearance">
+            <TabItem Header="Appearances">
                 <Grid>
                     <Grid.RowDefinitions>
                         <RowDefinition />
@@ -140,7 +140,9 @@
                               ItemsSource="{Binding AvailableColors}"
                               ItemTemplate="{StaticResource ColourPickerTemplate}" />
                         </ui:PreferencesField>
-
+                        <ui:PreferencesField Header="Show Space as ␣">
+                            <CheckBox IsChecked="{Binding Settings.ShowSpaceAsIcon}" Content="shows space as ' ␣ ' instead of '   '" />
+                        </ui:PreferencesField>
                         <ui:PreferencesField Header="Shortcuts Only">
                             <CheckBox IsChecked="{Binding Settings.DetectShortcutsOnly}" Content="shows only keys which are listed in keymaps folder" />
                         </ui:PreferencesField>


### PR DESCRIPTION
For this issue: [#165](https://github.com/Code52/carnac/issues/165 )
I added an checkbox with all the other options under Appearance, which when checked will display spaces as ␣, not too sure what to call that character though.

First time contributing, so tell me if I did something wrong :)

Fixes #165 
Fixes #198 