### PR TITLE
Filtered Processes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ src/Carnac.sln.ide/
 # Cake - Uncomment if you are using it
 tools/**
 !tools/packages.config
+/src/.vs/Carnac/v15/Server/sqlite3

--- a/src/Carnac.Logic/Models/PopupSettings.cs
+++ b/src/Carnac.Logic/Models/PopupSettings.cs
@@ -65,6 +65,9 @@ namespace Carnac.Logic.Models
         [NotifyProperty(AlsoNotifyFor = new[] { "Margins" })]
         public int RightOffset { get; set; }
 
+        [DefaultValue("")]
+        public string ProcessFilterExpression { get; set;  }
+
         public double ScaleTransform
         {
             get { return Placement == NotificationPlacement.TopLeft || Placement == NotificationPlacement.TopRight ? 1 : -1; }

--- a/src/Carnac.Tests/KeyProviderTests.cs
+++ b/src/Carnac.Tests/KeyProviderTests.cs
@@ -5,6 +5,7 @@ using Carnac.Logic;
 using Carnac.Logic.KeyMonitor;
 using Microsoft.Win32;
 using NSubstitute;
+using SettingsProviderNet;
 using Xunit;
 
 namespace Carnac.Tests
@@ -13,12 +14,14 @@ namespace Carnac.Tests
     {
         readonly IPasswordModeService passwordModeService;
         readonly IDesktopLockEventService desktopLockEventService;
+        readonly ISettingsProvider settingsProvider;
 
         public KeyProviderTests()
         {
             passwordModeService = new PasswordModeService();
             desktopLockEventService = Substitute.For<IDesktopLockEventService>();
             desktopLockEventService.GetSessionSwitchStream().Returns(Observable.Never<SessionSwitchEventArgs>());
+            settingsProvider = Substitute.For<ISettingsProvider>();
         }
 
         [Fact]
@@ -26,7 +29,7 @@ namespace Carnac.Tests
         {
             // arrange
             var player = KeyStreams.CtrlShiftL();
-            var provider = new KeyProvider(player, passwordModeService, desktopLockEventService);
+            var provider = new KeyProvider(player, passwordModeService, desktopLockEventService, settingsProvider);
 
             // act
             var processedKeys = await provider.GetKeyStream().ToList();
@@ -40,7 +43,7 @@ namespace Carnac.Tests
         {
             // arrange
             var player = KeyStreams.ShiftL();
-            var provider = new KeyProvider(player, passwordModeService, desktopLockEventService);
+            var provider = new KeyProvider(player, passwordModeService, desktopLockEventService, settingsProvider);
 
             // act
             var processedKeys = await provider.GetKeyStream().ToList();
@@ -55,7 +58,7 @@ namespace Carnac.Tests
         {
             // arrange
             var player = KeyStreams.LetterL();
-            var provider = new KeyProvider(player, passwordModeService, desktopLockEventService);
+            var provider = new KeyProvider(player, passwordModeService, desktopLockEventService, settingsProvider);
 
             // act
             var processedKeys = await provider.GetKeyStream().ToList();
@@ -69,7 +72,7 @@ namespace Carnac.Tests
         {
             // arrange
             var player = KeyStreams.Number1();
-            var provider = new KeyProvider(player, passwordModeService, desktopLockEventService);
+            var provider = new KeyProvider(player, passwordModeService, desktopLockEventService, settingsProvider);
 
             // act
             var processedKeys = await provider.GetKeyStream().ToList();
@@ -83,7 +86,7 @@ namespace Carnac.Tests
         {
             // arrange
             var player = KeyStreams.ExclaimationMark();
-            var provider = new KeyProvider(player, passwordModeService, desktopLockEventService);
+            var provider = new KeyProvider(player, passwordModeService, desktopLockEventService, settingsProvider);
 
             // act
             var processedKeys = await provider.GetKeyStream().ToList();
@@ -97,7 +100,7 @@ namespace Carnac.Tests
         {
             // arrange
             var player = KeyStreams.WinkeyE();
-            var provider = new KeyProvider(player, passwordModeService, desktopLockEventService);
+            var provider = new KeyProvider(player, passwordModeService, desktopLockEventService, settingsProvider);
 
             // act
             var processedKeys = await provider.GetKeyStream().ToList();

--- a/src/Carnac.Tests/MessageProviderFacts.cs
+++ b/src/Carnac.Tests/MessageProviderFacts.cs
@@ -10,6 +10,7 @@ using Carnac.Logic.KeyMonitor;
 using Carnac.Logic.Models;
 using Microsoft.Win32;
 using NSubstitute;
+using SettingsProviderNet;
 using Xunit;
 
 namespace Carnac.Tests
@@ -30,8 +31,9 @@ namespace Carnac.Tests
             var source = Substitute.For<IInterceptKeys>();
             source.GetKeyStream().Returns(keysStreamSource);
             var desktopLockEventService = Substitute.For<IDesktopLockEventService>();
+            var settingsProvider = Substitute.For<ISettingsProvider>();
             desktopLockEventService.GetSessionSwitchStream().Returns(Observable.Never<SessionSwitchEventArgs>());
-            var keyProvider = new KeyProvider(source, new PasswordModeService(), desktopLockEventService);
+            var keyProvider = new KeyProvider(source, new PasswordModeService(), desktopLockEventService, settingsProvider);
             return new MessageProvider(shortcutProvider, keyProvider, new PopupSettings());
         }
 

--- a/src/Carnac/App.xaml.cs
+++ b/src/Carnac/App.xaml.cs
@@ -27,9 +27,9 @@ namespace Carnac
 
         public App()
         {
-            var keyProvider = new KeyProvider(InterceptKeys.Current, new PasswordModeService(), new DesktopLockEventService());
             settingsProvider = new SettingsProvider(new RoamingAppDataStorage("Carnac"));
             settings = settingsProvider.GetSettings<PopupSettings>();
+            var keyProvider = new KeyProvider(InterceptKeys.Current, new PasswordModeService(), new DesktopLockEventService(), settingsProvider);
             messageProvider = new MessageProvider(new ShortcutProvider(), keyProvider, settings);
         }
 

--- a/src/Carnac/UI/PreferencesView.xaml
+++ b/src/Carnac/UI/PreferencesView.xaml
@@ -7,7 +7,7 @@
                       xmlns:utilities="clr-namespace:Carnac.Utilities"
                       xmlns:carnac="clr-namespace:Carnac"
                       x:Class="Carnac.UI.PreferencesView"
-                      Width="610" Height="420" Icon="../icon.ico"
+                      Width="610" Height="430" Icon="../icon.ico"
                       Foreground="{DynamicResource BlackBrush}"
                       d:DataContext="{d:DesignInstance ui:PreferencesViewModel}" mc:Ignorable="d"
                       ShowTitleBar="False" ShowMinButton="False" ShowMaxRestoreButton="False"
@@ -149,6 +149,12 @@
 						</ui:PreferencesField>
 						<ui:PreferencesField Header="Show Application Icon">
                             <CheckBox IsChecked="{Binding Settings.ShowApplicationIcon}" />
+                        </ui:PreferencesField>
+                        <ui:PreferencesField Header="Process Filter">
+                            <StackPanel Orientation="Vertical">
+                                <TextBox Text="{Binding Settings.ProcessFilterExpression}"></TextBox>
+                                <TextBlock HorizontalAlignment="Right">Only show keys from processes matching this regular expression</TextBlock>
+                            </StackPanel>
                         </ui:PreferencesField>
                     </StackPanel>
                     <StackPanel HorizontalAlignment="Right" Orientation="Horizontal" Grid.Row="1" Margin="5">


### PR DESCRIPTION
## Use Case
When doing a presentation, I really only want key presses to be shown if they are for specific applications, such as Visual Studio or another text editor.  This will prevent passwords and other secrets from accidentally being shown as they are typed into other applications.

## Proposed Solution
Add an option to the settings to allow a regular expression filter for process names to whitelist key presses from.  If no filter, or an invalid regular expression is supplied, Carnac should behave as if unfiltered (ie. today's current behavior).

## Notes
This is my first pull request in any repo, and I'm new to git.  If this isn't the correct process or procedure, I apologize.   If I should have done anything different, just let me know and I will correct it.

Thanks!

