### PR TITLE
Display "PageDown" instead of "Next" when the [PageDown] key is pressed.

### DIFF
--- a/src/Carnac.Logic/ReplaceKey.cs
+++ b/src/Carnac.Logic/ReplaceKey.cs
@@ -102,7 +102,7 @@ namespace Carnac.Logic
 
         public static string Sanitise(this Keys key)
         {
-             return Replacements.ContainsKey(key) ? Replacements[key] : string.Format(key.ToString());
+            return Replacements.ContainsKey(key) ? Replacements[key] : string.Format(key.ToString());
         }
 
         public static bool SanitiseShift(this Keys key, out string sanitisedKeyInput)

--- a/src/Carnac.Logic/ReplaceKey.cs
+++ b/src/Carnac.Logic/ReplaceKey.cs
@@ -78,6 +78,7 @@ namespace Carnac.Logic
             {Keys.RShiftKey, "Shift"},
             {Keys.LWin, "Win"},
             {Keys.RWin, "Win"},
+            {Keys.Next, "PageDown"}
         };
 
         public static Keys? ToKey(string keyText)
@@ -101,7 +102,7 @@ namespace Carnac.Logic
 
         public static string Sanitise(this Keys key)
         {
-            return Replacements.ContainsKey(key) ? Replacements[key] : string.Format(key.ToString());
+             return Replacements.ContainsKey(key) ? Replacements[key] : string.Format(key.ToString());
         }
 
         public static bool SanitiseShift(this Keys key, out string sanitisedKeyInput)


### PR DESCRIPTION
Fix this bug: Pressing the [Page Up] key correctly displays the string "PageUp," but pressing the [Page Down] key incorrectly displays the string "Next."

This happens because Windows sends the value Keys.Next when the [Page Down] key is pressed, and the value is just converted to string before display.

To fix this, add an entry to ReplaceKey.cs:Replacements so that ReplaceKey.cs:Sanitise() will return "PageDown" when given the value Keys.Next.

System.Windows.Forms.Keys assigns the value 33 to both Prior and PageUp, and assigns the value 34 to both Next and PageDown.

It may be that Windows correctly returns Keys.PageUp instead of Keys.Prior because "PageUp" < "Prior," and incorrectly returns Keys.Next instead of Keys.PageDown because "Next" < "PageDown."

In any case, replacing Keys.Next with "PageDown" makes the output more consistent.
