### PR TITLE
Add option to toggle multiple representation of repeated keystrokes

### DIFF
--- a/src/Carnac.Logic/MessageProvider.cs
+++ b/src/Carnac.Logic/MessageProvider.cs
@@ -36,7 +36,7 @@ namespace Carnac.Logic
                 .Scan(new ShortcutAccumulator(), (acc, key) => acc.ProcessKey(shortcutProvider, key))
                 .Where(c => c.HasCompletedValue)
                 .SelectMany(c => c.GetMessages())
-                .Scan(new Message(), (acc, key) => Message.MergeIfNeeded(acc, key))
+                .Scan(new Message(), (acc, key) => Message.MergeIfNeeded(acc, key, settings.AbbrevRepeatedKeystrokes))
                 .Where(m =>
                 {
                     if (settings.DetectShortcutsOnly && settings.ShowOnlyModifiers)

--- a/src/Carnac.Logic/Models/Message.cs
+++ b/src/Carnac.Logic/Models/Message.cs
@@ -17,6 +17,7 @@ namespace Carnac.Logic.Models
         readonly bool isShortcut;
         readonly bool isModifier;
         readonly bool isDeleting;
+        static bool abbrevRepeatedKeystrokes;
         readonly DateTime lastMessage;
         readonly Message previous;
 
@@ -97,18 +98,19 @@ namespace Carnac.Logic.Models
 
         public bool IsModifier { get { return isModifier; } }
 
-        public Message Merge(Message other)
+        public Message Merge(Message other, bool abbrevRepeatedKeystrokes)
         {
             return new Message(this, other);
         }
 
         static readonly TimeSpan OneSecond = TimeSpan.FromSeconds(1);
 
-        public static Message MergeIfNeeded(Message previousMessage, Message newMessage)
+        public static Message MergeIfNeeded(Message previousMessage, Message newMessage, bool settingsAbbrevRepeatedKeystrokes)
         {
+            Message.abbrevRepeatedKeystrokes = settingsAbbrevRepeatedKeystrokes;
             return ShouldCreateNewMessage(previousMessage, newMessage)
                 ? newMessage
-                : previousMessage.Merge(newMessage);
+                : previousMessage.Merge(newMessage, abbrevRepeatedKeystrokes);
         }
 
         static bool ShouldCreateNewMessage(Message previous, Message current)
@@ -137,7 +139,7 @@ namespace Carnac.Logic.Models
                   if (acc.Any())
                   {
                       var last = acc.Last();
-                      if (last.IsRepeatedBy(curr))
+                      if (last.IsRepeatedBy(curr) && abbrevRepeatedKeystrokes)
                       {
                           last.IncrementRepeat();
                       }

--- a/src/Carnac.Logic/Models/PopupSettings.cs
+++ b/src/Carnac.Logic/Models/PopupSettings.cs
@@ -87,6 +87,19 @@ namespace Carnac.Logic.Models
 
         public bool DetectShortcutsOnly { get; set; }
         public bool ShowApplicationIcon { get; set; }
+        public bool AbbrevRepeatedKeystrokes
+        {
+            get
+            {
+                return _AbbrevRepeatedKeystrokes;
+            }
+            set
+            {
+
+                _AbbrevRepeatedKeystrokes = value;
+            }
+        }
+        private bool _AbbrevRepeatedKeystrokes { get; set; }
         public bool SettingsConfigured { get; set; }
         public bool ShowOnlyModifiers { get; set; }
     }

--- a/src/Carnac/UI/PreferencesView.xaml
+++ b/src/Carnac/UI/PreferencesView.xaml
@@ -150,6 +150,9 @@
 						<ui:PreferencesField Header="Show Application Icon">
                             <CheckBox IsChecked="{Binding Settings.ShowApplicationIcon}" />
                         </ui:PreferencesField>
+                        <ui:PreferencesField Header="Abbr. Repeated Letters">
+                            <CheckBox IsChecked="{Binding Settings.AbbrevRepeatedKeystrokes}" />
+                        </ui:PreferencesField>
                     </StackPanel>
                     <StackPanel HorizontalAlignment="Right" Orientation="Horizontal" Grid.Row="1" Margin="5">
                         <Button Width="150" Margin="0 0 5 0" Content="Reset to Defaults" Command="{Binding ResetToDefaultsCommand}" />


### PR DESCRIPTION
Added a checkbox to the Appearance Tab that allows the user to enable or disable the multiplier format for displaying repeated keystrokes.