### PR TITLE
Update to latest cake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,4 +23,4 @@ src/Carnac.sln.ide/
 # Cake - Uncomment if you are using it
 tools/**
 !tools/packages.config
-/src/.vs/Carnac/v15/Server/sqlite3
+.vs/

--- a/build.cake
+++ b/build.cake
@@ -2,8 +2,8 @@
 #tool "nuget:?package=Squirrel.Windows";
 #tool "nuget:?package=GitVersion.CommandLine";
 
-#addin "nuget:?package=Cake.FileHelpers&version=1.0.4";
-#addin "nuget:?package=Cake.Squirrel&version=0.12.0";
+#addin "nuget:?package=Cake.FileHelpers&version=3.2.1";
+#addin "nuget:?package=Cake.Squirrel&version=0.15.1";
 #addin "nuget:?package=Newtonsoft.Json";
 using Newtonsoft.Json;
 

--- a/build.cake
+++ b/build.cake
@@ -80,7 +80,7 @@ Task("Package-Squirrel")
 	.IsDependentOn("Run-Unit-Tests")
 	.Does(() =>
 	{
-		var syncReleasesDir = toolsDir + Directory("squirrel.windows/tools");
+		var syncReleasesDir = toolsDir + Directory("squirrel.windows.1.9.1/tools");
 
 		EnsureDirectoryExists(deployDir);
 		EnsureDirectoryExists(squirrelDeployDir);

--- a/tools/packages.config
+++ b/tools/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-    <package id="Cake" version="0.19.4" />
+    <package id="Cake" version="0.38.2" />
 </packages>


### PR DESCRIPTION
Having some problems building locally on a vanilla Windows 10 VM, in particular at the build script stage.

```
PS C:\Users\shiftkey\src\carnac> .\build.ps1  
Preparing to run build script...
Running build script...
Analyzing build script...
Processing build script...
Installing tools...
Installing addins...
Downloading and installing Roslyn...
Installing packages (using https://packages.nuget.org/api/v2)...
Copying files...
Copying Roslyn.Compilers.CSharp.dll...
Copying Roslyn.Compilers.dll...
Deleting installation directory...
Compiling build script...
Error: C:/Users/shiftkey/src/carnac/build.cake(15,21): error CS1525: Invalid expression term ''
```

Let's see what it takes to have us running on the latest version of Cake.

 - [x] update Cake and related dependencies to latest version
 - [x] figure out why `Package-Squirrel` currently fails