### PR TITLE
pin build dependencies to specific versions

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,6 +4,9 @@ skip_branch_with_pr: true
 skip_tags: false
 assembly_info:
   patch: false
+branches:
+  only:
+    - master
 environment:
   Version: $(APPVEYOR_BUILD_VERSION)
   GithubRepo: $(APPVEYOR_REPO_NAME)

--- a/build.cake
+++ b/build.cake
@@ -1,10 +1,10 @@
 #tool "nuget:?package=xunit.runners&version=1.9.2";
-#tool "nuget:?package=Squirrel.Windows";
-#tool "nuget:?package=GitVersion.CommandLine";
+#tool "nuget:?package=Squirrel.Windows&version=1.9.1";
+#tool "nuget:?package=GitVersion.CommandLine&version=5.3.6";
 
 #addin "nuget:?package=Cake.FileHelpers&version=3.2.1";
 #addin "nuget:?package=Cake.Squirrel&version=0.15.1";
-#addin "nuget:?package=Newtonsoft.Json";
+#addin "nuget:?package=Newtonsoft.Json&version=12.0.3";
 using Newtonsoft.Json;
 
 var target = Argument("target", "Default");


### PR DESCRIPTION
Builds upon #248 to address some warnings about floating dependencies.

These seem to work with the latest versions available on NuGet.