### PR TITLE
also build tags

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,6 +7,7 @@ assembly_info:
 branches:
   only:
     - master
+    - \d*\.\d*\.\d*/
 environment:
   Version: $(APPVEYOR_BUILD_VERSION)
   GithubRepo: $(APPVEYOR_REPO_NAME)


### PR DESCRIPTION
The Appveyor change in #251 was too blunt, as this is also applied to tags.

Putting in an additional rule so we can generate releases from a pushed tag.