### PR TITLE
simplify the build script run on appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,7 +14,7 @@ environment:
   GithubAuthToken:
     secure: qgh2y38nOEG/eAnQe0EwNSqMDSXf9akPDwJI5Yasvyiemh5GBbbzkDIleAhGak6i
 build_script:
-- cmd: PowerShell -Version 2.0 .\build.ps1 -Configuration Release -Experimental -ScriptArgs '--authtoken="%GithubAuthToken%"'
+- ps: .\build.ps1 -Configuration Release -Experimental
 test:
   assemblies:
     - '**\Carnac.Tests.dll'

--- a/build.cake
+++ b/build.cake
@@ -10,7 +10,7 @@ using Newtonsoft.Json;
 var target = Argument("target", "Default");
 var configuration = Argument("configuration", "Debug");
 var githubRepo = Argument("githubrepo", "Code52/carnac");
-var githubAuthToken = Argument("authtoken", "");
+var githubAuthToken = Argument("GithubAuthToken", "");
 
 var githubRepoUrl = $"https://github.com/{githubRepo}";
 var solutionFile = "./src/Carnac.sln";


### PR DESCRIPTION
PowerShell v2 requires .NET 2 to be installed, so let's see if we can simplify the build script and address #253 at the same time.

Resolves #253