### PR TITLE
Update chocolatey things

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A keyboard logging and presentation utility for presentations, screencasts, and 
 You can install the latest version of Carnac via [Chocolatey](https://chocolatey.org/):
 
 ```ps
-cinst carnac
+choco install carnac
 ```
 
 Alternatively, you can grab the latest zip file from [here](https://github.com/Code52/carnac/releases/latest), unpack it and run `Setup.exe`.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A keyboard logging and presentation utility for presentations, screencasts, and 
 
 ### Installation
 
-You can install the latest version of Carnac via [Chocolatey](https://chocolatey.org/):
+You can install the latest version of [Carnac](https://community.chocolatey.org/packages/carnac) via [Chocolatey](https://chocolatey.org/):
 
 ```ps
 choco install carnac


### PR DESCRIPTION
Updated the README with the following changes:

* The `cinst` command is being [deprecated in the next version of Chocolatey CLI](https://github.com/chocolatey/choco/issues/2642). Replaced it with the correct command.
* Added a link to the carnac package page on the Chocolatey Community Repository.